### PR TITLE
Add appveyor CI for windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,45 @@
+cache:
+  - c:\cargo\registry
+  - c:\cargo\git
+  - c:\projects/subunit-rust\target
+
+init:
+  - mkdir c:\cargo
+  - mkdir c:\rustup
+  - SET PATH=c:\cargo\bin;%PATH%
+
+clone_folder: c:\project\subunit-rust
+
+environment:
+  CARGO_HOME: "c:\\cargo"
+  RUSTUP_HOME: "c:\\rustup"
+  CARGO_TARGET_DIR: "c:\\projects\\subunit-rust\\target"
+  global:
+    PROJECT_NAME: subunit-rust
+    RUST_BACKTRACE: full
+  matrix:
+    - TARGET: i686-pc-windows-gnu
+      CHANNEL: stable
+    - TARGET: i686-pc-windows-msvc
+      CHANNEL: stable
+    - TARGET: x86_64-pc-windows-gnu
+      CHANNEL: stable
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: stable
+
+matrix:
+  fast_finish: true
+
+# Install Rust and Cargo
+# (Based on from https://github.com/rust-lang/libc/blob/master/appveyor.yml)
+install:
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET% --no-modify-path
+  - if defined MSYS2_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS2_BITS%\bin
+  - rustc -V
+  - cargo -V
+
+build: false
+
+test_script:
+  - cargo test --verbose --all

--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@ Subunit Rust
 ============
 [![subunit-rust on Travis CI][travis-image]][travis]
 [![subunit-rust on crates.io][cratesio-image]][cratesio]
+[![subunit-rust on Appveyor CI][appveyor-image]][appveyor]
 
 [travis-image]: https://travis-ci.org/mtreinish/subunit-rust.svg?branch=master
 [travis]: https://travis-ci.org/mtreinish/subunit-rust
 [cratesio-image]: https://img.shields.io/crates/v/subunit-rust.svg
 [cratesio]: https://crates.io/crates/subunit-rust
+[appveyor-image]: https://img.shields.io/appveyor/ci/mtreinish/subunit-rust/master.svg
+[appveyor]: https://ci.appveyor.com/project/mtreinish/subunit-rust
+
 
 This repo contains a implementation of the subunit protocol in Rust. It
 provides an interface for both writing and reading subunit streams natively in


### PR DESCRIPTION
There is no reason subunit-rust shouldn't work on windows environments,
this commit adds the CI setup to verify it works there too, since I
don't have a local environment to test on.