### PR TITLE
Switch crc lib to crc32fast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ travis-ci = {repository = "mtreinish/subunit-rust"}
 [dependencies]
 chrono = "0.4.11"
 byteorder = "1.3"
-crc = "^1.0.0"
+crc32fast = "1.3"


### PR DESCRIPTION
This commit updates the crc library we use to be crc32fast, we only are
concerned with generating a crc32 hash and the crc library api makes
this a bit more involved than it needs to be in newer versions. The
crc32fast library enables us to easily generate this hash and do it
faster by levarging SIMD instrinsics.