### PR TITLE
Bump version to prepare for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "subunit-rust"
 description = "A subunit v2 protocol implementation in Rust"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This commit bumps the version number in the Cargo.toml file to prepare
for the pending 0.2.0 release. This release really just changes the crc
library we use to improve the performance of checksumming.