### PR TITLE
Push parser and async stream support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,16 @@ readme = "README.md"
 repository = "https://github.com/mtreinish/subunit-rust"
 version = "0.2.0"
 
+[features]
+async = ["dep:async-stream", "dep:tokio", "dep:tokio-stream"]
+default = ["async", "sync"]
+sync = []
+
 [dependencies]
-byteorder = "1.3"
+async-stream = { version = "0.3", optional = true }
 chrono = "0.4.11"
 crc32fast = "1.3"
 enumset = "1.1.3"
+thiserror = "1.0.62"
+tokio = { version = "1.0", optional = true, features = ["full"] }
+tokio-stream = { version = "0.1", optional = true }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,0 +1,111 @@
+//! Deserialization of events
+
+use crate::{types::number::SubunitNumber, Error, GenResult};
+
+/// Deserialization of Subunit types from a byte slice.
+pub trait Deserializable {
+    /// The minimum number of bytes that might be required to deserialize this
+    /// type from the front of the slice. If the type cannot be deserialized at
+    /// all, return an error.
+    ///
+    /// The count is a minimum because additional bytes may be required once the
+    /// actual value is available. For instance, the minimum bytes for a UTF8
+    /// codepoint is 1, buf if the codepoint is a multi-byte codepoint,
+    /// additional bytes are required, and because of the way UTF8 is encoded,
+    /// each byte can only reveal the requirement for one more byte.
+    ///
+    /// However for error handling, knowing how many bytes to skip over is very
+    /// useful, so when required_bytes returns a value <= len(bytes), the caller
+    /// can use that to skip over bytes to the next thing, if deserialising
+    /// fails.
+    fn required_bytes(bytes: &[u8]) -> GenResult<usize>;
+    /// Deserialize the type from the slice.
+    fn deserialize(bytes: &[u8]) -> GenResult<(Self, usize)>
+    where
+        Self: Sized;
+}
+
+impl Deserializable for u8 {
+    fn required_bytes(_bytes: &[u8]) -> GenResult<usize> {
+        Ok(1)
+    }
+
+    fn deserialize(bytes: &[u8]) -> GenResult<(u8, usize)> {
+        if bytes.len() < u8::required_bytes(bytes)? {
+            return Err(Error::NotEnoughBytes.into());
+        }
+        Ok((bytes[0], 1))
+    }
+}
+
+impl Deserializable for u16 {
+    fn required_bytes(_bytes: &[u8]) -> GenResult<usize> {
+        Ok(2)
+    }
+
+    fn deserialize(bytes: &[u8]) -> GenResult<(u16, usize)> {
+        if bytes.len() < u16::required_bytes(bytes)? {
+            return Err(Error::NotEnoughBytes.into());
+        }
+        Ok((u16::from_be_bytes(bytes[..2].try_into().unwrap()), 2))
+    }
+}
+
+impl Deserializable for String {
+    fn required_bytes(bytes: &[u8]) -> GenResult<usize> {
+        let required = SubunitNumber::required_bytes(bytes)?;
+        if bytes.len() < required {
+            return Ok(required);
+        }
+        let (length, required) = SubunitNumber::deserialize(&bytes[..required])?;
+        // The length is the number of bytes in the string, plus the length of the number prefixing it
+        Ok(length.as_u32() as usize + required)
+    }
+
+    fn deserialize(bytes: &[u8]) -> GenResult<(String, usize)> {
+        let (vec, length) = Vec::<u8>::deserialize(bytes)?;
+
+        String::from_utf8(vec)
+            .map(|s| (s, length))
+            .map_err(|_| Error::InvalidUTF8Sequence.into())
+    }
+}
+
+impl Deserializable for Vec<u8> {
+    fn required_bytes(bytes: &[u8]) -> GenResult<usize> {
+        String::required_bytes(bytes)
+    }
+
+    fn deserialize(bytes: &[u8]) -> GenResult<(Vec<u8>, usize)> {
+        let required = String::required_bytes(bytes)?;
+        if bytes.len() < required {
+            return Err(Error::NotEnoughBytes.into());
+        }
+        let (length, required) = SubunitNumber::deserialize(&bytes[..required])?;
+        // The length is the number of bytes in the string, plus the length of the number prefixing it
+        if bytes.len() < length.as_u32() as usize + required {
+            return Err(Error::NotEnoughBytes.into());
+        }
+        Ok((
+            bytes[required..length.as_u32() as usize + required].to_vec(),
+            length.as_u32() as usize + required,
+        ))
+    }
+}
+
+impl Deserializable for Vec<String> {
+    fn required_bytes(_bytes: &[u8]) -> GenResult<usize> {
+        unreachable!("Vec<String>::required_bytes is not required for this implementation");
+    }
+
+    fn deserialize(bytes: &[u8]) -> GenResult<(Vec<String>, usize)> {
+        let (length, mut offset) = SubunitNumber::deserialize(bytes)?;
+        let mut result = vec![];
+        for _ in 0..length.as_u32() {
+            let (string, size) = String::deserialize(&bytes[offset..])?;
+            result.push(string);
+            offset += size;
+        }
+        Ok((result, offset))
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,6 @@
+//! Convienence functions for reading and writing subunit packets in different IO models
+
+#[cfg(feature = "async")]
+pub mod r#async;
+#[cfg(feature = "sync")]
+pub mod sync;

--- a/src/io/async.rs
+++ b/src/io/async.rs
@@ -1,0 +1,76 @@
+//! Asynchronous I/O module
+
+use std::collections::VecDeque;
+
+use async_stream::try_stream;
+use tokio::io::AsyncReadExt;
+use tokio_stream::Stream;
+
+use crate::{deserialize::Deserializable, types::stream::ScannedItem, Error, GenError, GenResult};
+
+async fn next<R: AsyncReadExt + Unpin>(
+    reader: &mut R,
+    buffer: &mut VecDeque<u8>,
+) -> GenResult<Option<ScannedItem>> {
+    let buf = buffer.make_contiguous();
+    let mut required_bytes = match ScannedItem::required_bytes(buf) {
+        Ok(v) => v,
+        Err(e) => Err(GenError::from(e))?,
+    };
+    while buf.len() < required_bytes {
+        match reader.read(buf).await {
+            Ok(0) => {
+                if buf.is_empty() {
+                    return Ok(None);
+                }
+
+                // By definition, we have a partial packet or partial codepoint
+                return Ok(Some(ScannedItem::Unknown(
+                    buffer.drain(..).collect(),
+                    Error::InvalidUTF8Sequence.into(),
+                )));
+            }
+            Ok(_) => (), // Might not be enough read yet
+            Err(e) => Err(GenError::from(e))?,
+        }
+        required_bytes = match ScannedItem::required_bytes(buf) {
+            Ok(v) => v,
+            Err(e) => Err(GenError::from(e))?,
+        };
+    }
+
+    // Now we have enough data to do something with it.
+
+    // TODO: scan rapidly and collect all UTF8 text in one go rather than depending on the optimiser to make it
+    // efficient.
+    match ScannedItem::deserialize(buf) {
+        Ok((event, used)) => {
+            buffer.drain(..used);
+            Ok(Some(event))
+        }
+        Err(e) => {
+            // We know from the loop above that we had enough bytes, and this is not IO: some form of junk.
+            // We have an invalid char or failed crc32 or similar.
+            Ok(Some(ScannedItem::Unknown(
+                buffer.drain(..required_bytes).collect(),
+                e,
+            )))
+        }
+    }
+}
+
+/// Iterate over a Readable, yielding the contents as `ScannedItems`.
+pub fn iter_stream<R: AsyncReadExt + Unpin>(
+    mut reader: R,
+) -> impl Stream<Item = GenResult<ScannedItem>> {
+    try_stream! {
+        // Maximum buffer needed to process subunit packets is 4MB
+        let mut buffer = VecDeque::<u8>::with_capacity(4 * 1024 * 1024);
+
+        // NB: its likely that an async-native version of the logic would produce a nicer state machine; OTOH this way way have just one implementation of the core.
+
+        while let Some(item) = next(&mut reader, &mut buffer).await? {
+            yield item;
+        }
+    }
+}

--- a/src/io/sync.rs
+++ b/src/io/sync.rs
@@ -1,0 +1,119 @@
+//! Synchronous I/O module
+
+use std::{collections::VecDeque, io::Read};
+
+use crate::{deserialize::Deserializable, types::stream::ScannedItem, Error, GenResult};
+
+/// Look for subunit events in an input stream.
+#[derive(Default, Debug)]
+pub struct Scanner<R> {
+    buffer: VecDeque<u8>,
+    reader: R,
+}
+
+/// Iterate over a Readable, yielding the contents as `ScannedItems`.
+pub fn iter_stream<R: Read>(reader: R) -> impl Iterator<Item = GenResult<ScannedItem>> {
+    // Maximum buffer needed to process subunit packets is 4MB
+    let buffer = VecDeque::<u8>::with_capacity(4 * 1024 * 1024);
+    Scanner { buffer, reader }
+}
+
+impl<R> Iterator for Scanner<R>
+where
+    R: Read,
+{
+    type Item = GenResult<ScannedItem>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let buf = self.buffer.make_contiguous();
+        let mut required_bytes = match ScannedItem::required_bytes(buf) {
+            Ok(v) => v,
+            Err(e) => return Some(Err(e)),
+        };
+        while buf.len() < required_bytes {
+            match self.reader.read(buf) {
+                Ok(0) => {
+                    if buf.is_empty() {
+                        return None;
+                    }
+                    // By definition, we have a partial packet or partial codepoint
+                    return Some(Ok(ScannedItem::Unknown(
+                        self.buffer.drain(..).collect(),
+                        Error::InvalidUTF8Sequence.into(),
+                    )));
+                }
+                Ok(_) => (), // Might not be enough read yet
+                Err(e) => return Some(Err(e.into())),
+            }
+            required_bytes = match ScannedItem::required_bytes(buf) {
+                Ok(v) => v,
+                Err(e) => return Some(Err(e)),
+            };
+        }
+
+        // Now we have enough data to do something with it.
+
+        // TODO: scan rapidly and collect all UTF8 text in one go rather than depending on the optimiser to make it
+        // efficient.
+        match ScannedItem::deserialize(buf) {
+            Ok((event, used)) => {
+                self.buffer.drain(..used);
+                Some(Ok(event))
+            }
+            Err(e) => {
+                // We know from the loop above that we had enough bytes, and this is not IO: some form of junk.
+                // We have an invalid char or failed crc32 or similar.
+                Some(Ok(ScannedItem::Unknown(
+                    self.buffer.drain(..required_bytes).collect(),
+                    e,
+                )))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use chrono::{TimeZone, Utc};
+
+    use crate::{
+        io::sync,
+        serialize::Serializable,
+        types::{event::Event, stream::ScannedItem, teststatus::TestStatus},
+    };
+
+    #[test]
+    fn test_write_full_test_event_with_file_content() {
+        let event = Event::new(TestStatus::InProgress)
+            .test_id("A_test_id")
+            .datetime(Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap())
+            .unwrap()
+            .tag("tag_a")
+            .tag("tag_b")
+            .mime_type("text/plain;charset=utf8")
+            .file_content("stdout:''", b"stdout content")
+            .build();
+        let event_a = Event::new(TestStatus::Failed)
+            .test_id("A_test_id")
+            .datetime(Utc.with_ymd_and_hms(2014, 7, 8, 9, 12, 1).unwrap())
+            .unwrap()
+            .tag("tag_a")
+            .tag("tag_b")
+            .build();
+
+        let mut buffer = event.to_vec().unwrap();
+        event_a.serialize(&mut buffer).unwrap();
+
+        for (parsed_event, event) in
+            sync::iter_stream(Cursor::new(&buffer)).zip([event, event_a].iter())
+        {
+            let parsed_event = parsed_event.unwrap();
+            let ScannedItem::Event(parsed_event) = parsed_event else {
+                panic!("Expected event, got {:?}", parsed_event);
+            };
+            assert_eq!(*event, parsed_event);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,467 +11,58 @@
 // limitations under the License.
 
 pub mod types {
+    pub mod event;
     pub mod eventfeatures;
+    pub mod file;
+    pub mod number;
+    pub mod stream;
     pub mod teststatus;
+    pub mod timestamp;
 }
 
-use std::{
-    error::Error,
-    fmt,
-    io::{Cursor, Read, Write},
-};
+pub mod deserialize;
+pub mod io;
+pub mod serialize;
+pub mod constants {
+    pub static V2_SIGNATURE: u8 = 0xb3;
+    pub static MAX_PACKET_LENGTH: u32 = 4 * 1024 * 1024;
+    pub static MAX_NUMBER_VALUE: u32 = 0x3fffffff;
+    pub static NUMBER_KIND_MASK: u8 = 0xc0;
+    pub static NUMBER_VALUE_MASK: u8 = 0x3f;
+    pub static VERSION2: u16 = 0x2000;
+}
 
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use chrono::{DateTime, TimeZone as _, Utc};
-use enumset::EnumSet;
+use std::fmt::Debug;
 
-use types::eventfeatures::EventFeatures;
-use types::teststatus::TestStatus;
+use thiserror::Error as ThisError;
 
-#[derive(Debug, Clone)]
-pub struct SizeError;
+#[derive(ThisError)]
+enum Error {
+    #[error("Value is too large to encode")]
+    TooLarge,
+    #[error("Invalid packet header: size {} < header size {}", _0, _1)]
+    LengthTooSmall(u32, u32),
+    #[error("Internal logic error {}", _0)]
+    Internal(String),
+    #[error("Invalid UTF8")]
+    InvalidUTF8Sequence,
+    #[error("Not enough bytes")]
+    NotEnoughBytes,
+    #[error("Invalid signature")]
+    InvalidSignature,
+    #[error("Bad version {:#x}", _0)]
+    BadVersion(u16),
+    #[error("CRC32 Mismatch measured: {:#02x} != stored: {:#02x}", _0, _1)]
+    CRC32Mismatch(u32, u32),
+    #[error("Invalid timestamp secs: {} nsecs: {}", _0, _1)]
+    InvalidTimestamp(u32, u32),
+}
 
-type GenError = Box<dyn Error>;
+impl Debug for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+type GenError = Box<dyn std::error::Error>;
 type GenResult<T> = Result<T, GenError>;
-
-const SIGNATURE: u8 = 0xb3;
-
-impl fmt::Display for SizeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Value is too large to encode")
-    }
-}
-
-impl Error for SizeError {
-    fn description(&self) -> &str {
-        "Value is too large to encode"
-    }
-
-    fn cause(&self) -> Option<&dyn Error> {
-        None
-    }
-}
-
-fn write_number<T: Write>(value: u32, mut ret: T) -> GenResult<T> {
-    // The first two bits encode the size:
-    // 00 = 1 byte
-    // 01 = 2 bytes
-    // 10 = 3 bytes
-    // 11 = 4 bytes
-
-    // 2^(8-2)
-    if value < 64 {
-        // Fits in one byte.
-        ret.write_u8(value as u8)?
-    // 2^(16-2):
-    } else if value < 16384 {
-        // Fits in two bytes.
-        // Set the size to 01.
-        ret.write_u16::<BigEndian>(value as u16 | 0x4000)?
-    // 2^(24-2):
-    } else if value < 4194304 {
-        // Fits in three bytes.
-        // Drop the two least significant bytes and set the size to 10.
-        ret.write_u8(((value >> 16) | 0x80) as u8)?;
-        ret.write_u16::<BigEndian>(value as u16)?;
-    // 2^(32-2):
-    } else if value < 1073741824 {
-        // Fits in four bytes.
-        // Set the size to 11.
-        ret.write_u32::<BigEndian>(value | 0xC0000000)?;
-    } else {
-        return Result::Err(Box::new(SizeError));
-    }
-    Result::Ok(ret)
-}
-
-fn write_utf8<T: Write>(string: &str, mut out: T) -> GenResult<T> {
-    out = write_number(string.len() as u32, out)?;
-    out.write_all(string.as_bytes())?;
-    Result::Ok(out)
-}
-
-pub fn read_number(reader: &mut Cursor<Vec<u8>>) -> GenResult<u32> {
-    let first = reader.read_u8()?;
-    // Get 2 first bits for prefix
-    let number_type = first & 0xc0;
-    // Get last 6 bits for first octet
-    let mut value = u32::from(first) & 0x3f;
-    // 0b00, 1 octet
-    if number_type == 0x00 {
-        Result::Ok(value)
-    // 0b01, 2octets
-    } else if number_type == 0x40 {
-        let suffix = reader.read_u8()?;
-        value = (value << 8) | u32::from(suffix);
-        Result::Ok(value)
-    // 0b10, 3 octets
-    } else if number_type == 0x80 {
-        let suffix = reader.read_u16::<BigEndian>()?;
-        value = (value << 16) | u32::from(suffix);
-        Result::Ok(value)
-    // 0b11, 4 octets
-    } else {
-        let suffix = reader.read_u32::<BigEndian>()?;
-        value = (value << 24) | suffix;
-        Result::Ok(value)
-    }
-}
-
-fn read_utf8(reader: &mut Cursor<Vec<u8>>) -> GenResult<String> {
-    let length = read_number(reader)?;
-    let mut bytes: Vec<u8> = Vec::new();
-    for _i in 0..length {
-        let byte = reader.read_u8()?;
-        bytes.push(byte)
-    }
-    let output = String::from_utf8(bytes)?;
-    Result::Ok(output)
-}
-
-fn read_packet(cursor: &mut Cursor<Vec<u8>>) -> GenResult<Event> {
-    let start_position = cursor.position();
-    let sig = cursor.read_u8()?;
-    let flags = cursor.read_u16::<BigEndian>()?;
-    let packet_length = read_number(cursor)?;
-    if sig != SIGNATURE {
-        panic!("Invalid signature");
-    }
-    let status = flags.into();
-    let masks = EnumSet::<EventFeatures>::from_repr_truncated(flags);
-    if flags >> 12 != 0x2 {
-        panic!("Invalid version {:#02x}", flags >> 12);
-    }
-
-    let timestamp = if masks.contains(EventFeatures::Timestamp) {
-        let seconds = cursor.read_u32::<BigEndian>()?;
-        let nanos = read_number(cursor)?;
-        Some(Utc.timestamp_opt(i64::from(seconds), nanos).unwrap())
-    } else {
-        None
-    };
-    let test_id = if masks.contains(EventFeatures::TestId) {
-        let id = read_utf8(cursor)?;
-        Some(id)
-    } else {
-        None
-    };
-    let tags = if masks.contains(EventFeatures::Tags) {
-        let count = read_number(cursor)?;
-        let mut tags_vec: Vec<String> = Vec::new();
-        for _i in 0..count {
-            let tag = read_utf8(cursor)?;
-            tags_vec.push(tag);
-        }
-        Some(tags_vec)
-    } else {
-        None
-    };
-    let mime_type = if masks.contains(EventFeatures::FileMimeType) {
-        let mime = read_utf8(cursor)?;
-        Some(mime)
-    } else {
-        None
-    };
-    let file_content;
-    let file_name;
-    if masks.contains(EventFeatures::FileContent) {
-        let name = read_utf8(cursor)?;
-        file_name = Some(name);
-        let file_length = read_number(cursor)?;
-        let mut content: Vec<u8> = Vec::new();
-        for _i in 0..file_length {
-            let byte = cursor.read_u8()?;
-            content.push(byte);
-        }
-        file_content = Some(content);
-    } else {
-        file_content = None;
-        file_name = None;
-    }
-
-    let route_code = if masks.contains(EventFeatures::RoutingCode) {
-        let code = read_utf8(cursor)?;
-        Some(code)
-    } else {
-        None
-    };
-    let _crc32 = cursor.read_u32::<BigEndian>()?;
-    let end_position = cursor.position();
-    if u64::from(packet_length) != (end_position - start_position) {
-        panic!("Packet length doesn't match");
-    }
-
-    let event = Event {
-        status,
-        test_id,
-        timestamp,
-        tags,
-        file_content,
-        file_name,
-        mime_type,
-        route_code,
-    };
-    Result::Ok(event)
-}
-
-pub fn parse_subunit<T: Read>(mut reader: T) -> GenResult<Vec<Event>> {
-    let mut output: Vec<Event> = Vec::new();
-    let mut contents: Vec<u8> = Vec::new();
-    reader.read_to_end(&mut contents)?;
-    let stream_length = contents.len() as u64;
-    let cursor = &mut Cursor::new(contents);
-    while cursor.position() < stream_length {
-        let packet = read_packet(cursor)?;
-        output.push(packet);
-    }
-    Result::Ok(output)
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Event {
-    pub status: TestStatus,
-    pub test_id: Option<String>,
-    pub timestamp: Option<DateTime<Utc>>,
-    pub file_name: Option<String>,
-    pub file_content: Option<Vec<u8>>,
-    pub mime_type: Option<String>,
-    pub route_code: Option<String>,
-    pub tags: Option<Vec<String>>,
-}
-
-impl Event {
-    pub fn write<T: Write>(&mut self, mut writer: T) -> GenResult<T> {
-        //  PACKET = SIGNATURE FLAGS PACKET_LENGTH TIMESTAMP? TESTID? TAGS?
-        //           MIME? FILECONTENT? ROUTING_CODE? CRC32
-        let flags = self.make_flags();
-        let timestamp = self.make_timestamp()?;
-        let test_id = self.make_test_id()?;
-        let tags = self.make_tags()?;
-        let mime_type = self.make_mime_type()?;
-        let file_content = self.make_file_content()?;
-        let routing_code = self.make_routing_code()?;
-
-        let mut buffer: Vec<u8> = Vec::new();
-        let mut body_length = timestamp.len() + test_id.len() + tags.len();
-        body_length += mime_type.len() + file_content.len();
-        body_length += routing_code.len();
-        // baseLength = header (minus variant length) + body + crc32
-        let base_length = 3 + body_length + 4;
-        // length of length depends on baseLength and its own length
-        // 63 - 1
-        let length;
-        if base_length <= 62 {
-            length = base_length + 1;
-        // 16383 - 2
-        } else if base_length <= 16381 {
-            length = base_length + 2;
-        // 4194303 - 3
-        } else if base_length <= 4194300 {
-            length = base_length + 3;
-        } else {
-            panic!("The packet is too large");
-        }
-
-        // Write event to stream
-        buffer.write_u8(SIGNATURE)?;
-        buffer.write_u16::<BigEndian>(flags)?;
-        buffer = write_number(length as u32, buffer)?;
-
-        buffer.write_all(&timestamp)?;
-        buffer.write_all(&test_id)?;
-        buffer.write_all(&tags)?;
-        buffer.write_all(&mime_type)?;
-        buffer.write_all(&file_content)?;
-        buffer.write_all(&routing_code)?;
-        // Flush buffer into output and digest to calculate crc32
-        let checksum = crc32fast::hash(&buffer);
-        writer.write_all(&buffer)?;
-        writer.write_u32::<BigEndian>(checksum)?;
-        Result::Ok(writer)
-    }
-
-    fn make_routing_code(&self) -> GenResult<Vec<u8>> {
-        let mut routing_code: Vec<u8> = Vec::new();
-        if self.route_code.is_some() {
-            routing_code = write_utf8(self.route_code.as_ref().unwrap(), routing_code)?;
-        }
-        Result::Ok(routing_code)
-    }
-
-    fn make_file_content(&self) -> GenResult<Vec<u8>> {
-        let mut file_content: Vec<u8> = Vec::new();
-        if let Some(file_name) = self.file_name.as_ref() {
-            if let Option::Some(ref body) = self.file_content {
-                file_content = write_utf8(file_name, file_content)?;
-                let len = self.file_content.as_ref().unwrap().len();
-                file_content = write_number(len as u32, file_content)?;
-                file_content.write_all(body)?;
-            }
-        }
-        Result::Ok(file_content)
-    }
-
-    fn make_mime_type(&self) -> GenResult<Vec<u8>> {
-        let mut mime_type: Vec<u8> = Vec::new();
-        if self.mime_type.is_some() {
-            mime_type = write_utf8(self.mime_type.as_ref().unwrap(), mime_type)?;
-        }
-        Result::Ok(mime_type)
-    }
-
-    fn make_tags(&self) -> GenResult<Vec<u8>> {
-        let mut tags: Vec<u8> = Vec::new();
-        if self.tags.is_some() {
-            let len = self.tags.as_ref().unwrap().len();
-            tags = write_number(len as u32, tags)?;
-            for tag in self.tags.as_ref().unwrap() {
-                tags = write_utf8(tag, tags)?;
-            }
-        }
-        Result::Ok(tags)
-    }
-
-    fn make_test_id(&self) -> GenResult<Vec<u8>> {
-        let mut test_id: Vec<u8> = Vec::new();
-        if self.test_id.is_some() {
-            let raw_id = self.test_id.as_ref().unwrap();
-            test_id = write_utf8(raw_id, test_id)?;
-        }
-        Result::Ok(test_id)
-    }
-
-    fn make_timestamp(&self) -> GenResult<Vec<u8>> {
-        let mut timestamp: Vec<u8> = Vec::new();
-        if self.timestamp.is_some() {
-            let secs = self.timestamp.unwrap().timestamp() as u32;
-            timestamp.write_u32::<BigEndian>(secs)?;
-            let subsec_nanos = self.timestamp.unwrap().timestamp_subsec_nanos();
-            timestamp = write_number(subsec_nanos, timestamp)?;
-        }
-        Result::Ok(timestamp)
-    }
-
-    fn make_flags(&self) -> u16 {
-        let mut flags = EnumSet::new();
-
-        if self.timestamp.is_some() {
-            flags |= EventFeatures::Timestamp;
-        }
-        if self.test_id.is_some() {
-            flags |= EventFeatures::TestId;
-        }
-        if self.tags.is_some() {
-            flags |= EventFeatures::Tags;
-        }
-        if self.mime_type.is_some() {
-            flags |= EventFeatures::FileMimeType;
-        }
-        if self.file_name.is_some() && self.file_content.is_some() {
-            flags |= EventFeatures::FileContent;
-        }
-        if self.route_code.is_some() {
-            flags |= EventFeatures::RoutingCode;
-        }
-
-        let version = 0x2000_u16; // version 0x2
-
-        version | flags.as_repr() | self.status as u16
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_write_event() {
-        let mut event = Event {
-            status: TestStatus::InProgress,
-            test_id: Some("A_test_id".to_string()),
-            timestamp: Some(Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap()),
-            tags: Some(vec!["tag_a".to_string(), "tag_b".to_string()]),
-            file_content: None,
-            file_name: None,
-            mime_type: None,
-            route_code: None,
-        };
-        let mut buffer: Vec<u8> = Vec::new();
-        //        use std::fs::File;
-        //        let mut buffer = File::create("/tmp/test.subunit").unwrap();
-
-        buffer = match event.write(buffer) {
-            Result::Ok(buffer) => buffer,
-            Result::Err(err) => panic!("Error while generating subunit {}", err),
-        };
-        let cursor = Cursor::new(buffer);
-        let out_events = parse_subunit(cursor);
-        let out_event = out_events.unwrap().pop().unwrap();
-        assert_eq!(event.test_id, out_event.test_id);
-        assert_eq!(event.status, out_event.status);
-        assert_eq!(event.timestamp, out_event.timestamp);
-        assert_eq!(event.tags, out_event.tags);
-        assert_eq!(event.file_content, out_event.file_content);
-        assert_eq!(event.file_name, out_event.file_name);
-        assert_eq!(event.mime_type, out_event.mime_type);
-        assert_eq!(event.route_code, out_event.route_code);
-    }
-
-    #[test]
-    fn test_write_full_test_event_with_file_content() {
-        let mut event = Event {
-            status: TestStatus::InProgress,
-            test_id: Some("A_test_id".to_string()),
-            timestamp: Some(Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap()),
-            tags: Some(vec!["tag_a".to_string(), "tag_b".to_string()]),
-            file_content: Some("stdout content".to_string().into_bytes()),
-            file_name: Some("stdout:''".to_string()),
-            mime_type: Some("text/plain;charset=utf8".to_string()),
-            route_code: None,
-        };
-        let mut event_a = Event {
-            status: TestStatus::Failed,
-            test_id: Some("A_test_id".to_string()),
-            timestamp: Some(Utc.with_ymd_and_hms(2014, 7, 8, 9, 12, 1).unwrap()),
-            tags: Some(vec!["tag_a".to_string(), "tag_b".to_string()]),
-            file_content: None,
-            file_name: None,
-            mime_type: None,
-            route_code: None,
-        };
-        let mut buffer: Vec<u8> = Vec::new();
-        //        use std::fs::File;
-        //        let mut buffer = File::create("/tmp/test2.subunit").unwrap();
-
-        buffer = match event.write(buffer) {
-            Result::Ok(buffer) => buffer,
-            Result::Err(err) => panic!("Error while generating subunit {}", err),
-        };
-        buffer = match event_a.write(buffer) {
-            Result::Ok(buffer) => buffer,
-            Result::Err(err) => panic!("Error while generating subunit {}", err),
-        };
-        let cursor = Cursor::new(buffer);
-        let mut out_events = parse_subunit(cursor).unwrap();
-        // Parse last packet
-        let out_event_a = out_events.pop().unwrap();
-        assert_eq!(event_a.test_id, out_event_a.test_id);
-        assert_eq!(event_a.status, out_event_a.status);
-        assert_eq!(event_a.timestamp, out_event_a.timestamp);
-        assert_eq!(event_a.tags, out_event_a.tags);
-        assert_eq!(event_a.file_content, out_event_a.file_content);
-        assert_eq!(event_a.file_name, out_event_a.file_name);
-        assert_eq!(event_a.mime_type, out_event_a.mime_type);
-        assert_eq!(event_a.route_code, out_event_a.route_code);
-        // Parse first packet
-        let out_event = out_events.pop().unwrap();
-        assert_eq!(event.test_id, out_event.test_id);
-        assert_eq!(event.status, out_event.status);
-        assert_eq!(event.timestamp, out_event.timestamp);
-        assert_eq!(event.tags, out_event.tags);
-        assert_eq!(event.file_content, out_event.file_content);
-        assert_eq!(event.file_name, out_event.file_name);
-        assert_eq!(event.mime_type, out_event.mime_type);
-        assert_eq!(event.route_code, out_event.route_code);
-    }
-}

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,0 +1,148 @@
+//! Serialization of events
+
+use std::io::Write;
+
+use crc32fast::Hasher;
+
+use crate::{types::number::SubunitNumber, GenResult};
+
+/// Trait that describes the serialization requirements for Subunit events.
+///
+/// Of particular note is the 'look ahead' `wire_size` method, which allows avoiding bulk data copying.
+pub trait Serializable {
+    /// Returns the size of a given implementor in bytes after serialization.
+    ///
+    /// This is used to calculate the size of the serialized event before data
+    /// copying takes place, in order to write the length-prefix for variable-sized
+    /// components.
+    fn wire_size(&self) -> GenResult<SubunitNumber>;
+
+    /// Write the instance to the given writer.
+    fn serialize<W: Write>(&self, out: &mut W) -> GenResult<()>;
+}
+
+impl<T> Serializable for Option<T>
+where
+    T: Serializable,
+{
+    fn wire_size(&self) -> GenResult<SubunitNumber> {
+        match self {
+            Some(inner) => inner.wire_size(),
+            None => SubunitNumber::new(0),
+        }
+    }
+
+    fn serialize<W: Write>(&self, out: &mut W) -> GenResult<()> {
+        match self {
+            Some(inner) => inner.serialize(out),
+            None => Ok(()),
+        }
+    }
+}
+
+impl<T> Serializable for Vec<T>
+where
+    T: Serializable,
+{
+    fn wire_size(&self) -> GenResult<SubunitNumber> {
+        let mut size = SubunitNumber::new(self.len() as u32)?.wire_size()?;
+        for item in self {
+            size = (size + item.wire_size()?)?;
+        }
+        Ok(size)
+    }
+
+    fn serialize<W: Write>(&self, out: &mut W) -> GenResult<()> {
+        SubunitNumber::try_from(self.len())?.serialize(out)?;
+        for item in self {
+            item.serialize(out)?;
+        }
+        Ok(())
+    }
+}
+
+impl<T, U> Serializable for (T, U)
+where
+    T: Serializable,
+    U: Serializable,
+{
+    fn wire_size(&self) -> GenResult<SubunitNumber> {
+        let (a, b) = self;
+        a.wire_size()? + b.wire_size()?
+    }
+
+    fn serialize<W: Write>(&self, out: &mut W) -> GenResult<()> {
+        let (a, b) = self;
+        a.serialize(out)?;
+        b.serialize(out)
+    }
+}
+
+impl Serializable for u8 {
+    fn wire_size(&self) -> GenResult<SubunitNumber> {
+        SubunitNumber::new(1)
+    }
+
+    fn serialize<W: Write>(&self, out: &mut W) -> GenResult<()> {
+        out.write_all(&[*self])?;
+        Ok(())
+    }
+}
+
+impl Serializable for u32 {
+    fn wire_size(&self) -> GenResult<SubunitNumber> {
+        SubunitNumber::new(4)
+    }
+
+    fn serialize<W: Write>(&self, out: &mut W) -> GenResult<()> {
+        out.write_all(&self.to_be_bytes())?;
+        Ok(())
+    }
+}
+
+impl Serializable for String {
+    fn wire_size(&self) -> GenResult<SubunitNumber> {
+        self.len() + SubunitNumber::new(self.len() as u32)?.wire_size()?
+    }
+
+    fn serialize<W: Write>(&self, out: &mut W) -> GenResult<()> {
+        SubunitNumber::try_from(self.len())?.serialize(out)?;
+        out.write_all(self.as_bytes())?;
+        Ok(())
+    }
+}
+
+pub struct Writer<'a, W> {
+    buffer: &'a mut W,
+    hasher: Hasher,
+}
+
+impl<'a, W> Writer<'a, W>
+where
+    W: Write,
+{
+    pub(crate) fn new(buffer: &'a mut W) -> Self {
+        Writer {
+            buffer,
+            hasher: Hasher::new(),
+        }
+    }
+
+    pub(crate) fn finalize(self) -> u32 {
+        self.hasher.finalize()
+    }
+}
+
+impl<W> Write for Writer<'_, W>
+where
+    W: Write,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.hasher.update(buf);
+        self.buffer.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.buffer.flush()
+    }
+}

--- a/src/types/event.rs
+++ b/src/types/event.rs
@@ -1,0 +1,623 @@
+use std::io::Write;
+
+use chrono::{DateTime, Utc};
+use crc32fast::Hasher;
+use enumset::EnumSet;
+
+use crate::{
+    constants::{self, V2_SIGNATURE},
+    deserialize::Deserializable,
+    serialize::{Serializable, Writer},
+    Error, GenResult,
+};
+
+use super::{
+    eventfeatures::EventFeatures, file::File, number::SubunitNumber, teststatus::TestStatus,
+    timestamp::Timestamp,
+};
+
+macro_rules! safe_read {
+    ($expr:expr) => {
+        match $expr {
+            ::std::result::Result::Ok(val) => val,
+            ::std::result::Result::Err(size) => {
+                return ::std::result::Result::Ok(size);
+            }
+        }
+    };
+}
+
+macro_rules! safe_de {
+    ($expr:expr) => {
+        match $expr {
+            ::std::result::Result::Ok(val) => val,
+            ::std::result::Result::Err(_size) => {
+                return ::std::result::Result::Err($crate::Error::NotEnoughBytes.into());
+            }
+        }
+    };
+}
+
+/// Construct an event incrementally
+pub struct EventBuilder(Event);
+
+impl EventBuilder {
+    pub fn test_id(mut self, test_id: &str) -> Self {
+        self.0.test_id = Some(test_id.to_string());
+        self
+    }
+
+    pub fn datetime(mut self, datetime: DateTime<Utc>) -> GenResult<Self> {
+        self.0.timestamp = Some(datetime.try_into()?);
+        Ok(self)
+    }
+
+    pub fn tag(mut self, tag: &str) -> Self {
+        if self.0.tags.is_none() {
+            self.0.tags = Some(Vec::new());
+        }
+        self.0.tags.as_mut().unwrap().push(tag.to_string());
+        self
+    }
+
+    pub fn mime_type(mut self, mime_type: &str) -> Self {
+        self.0.file.mime_type = Some(mime_type.to_string());
+        self
+    }
+
+    pub fn file_content(mut self, name: &str, content: &[u8]) -> Self {
+        self.0.file.file = Some((name.to_string(), content.to_vec()));
+        self
+    }
+
+    pub fn end_of_file(mut self) -> Self {
+        self.0.file.eof = true;
+        self
+    }
+
+    pub fn runnable(mut self) -> Self {
+        self.0.runnable = true;
+        self
+    }
+
+    pub fn route_code(mut self, route_code: &str) -> Self {
+        self.0.route_code = Some(route_code.to_string());
+        self
+    }
+
+    pub fn build(self) -> Event {
+        self.0
+    }
+}
+
+impl EventBuilder {}
+
+/// A subunit event
+///
+/// [Docs](https://github.com/testing-cabal/subunit/blob/fc698775674fcbdb9fcc8286d8358c7185647db4/README.rst?plain=1#L147)
+#[derive(Debug, Clone, PartialEq)]
+pub struct Event {
+    /// The status of the event
+    pub status: TestStatus,
+    /// The test id if present
+    pub test_id: Option<String>,
+    /// The timestamp if present
+    pub timestamp: Option<Timestamp>,
+    /// File content details
+    pub file: File,
+    /// The routing code if present. Routing codes are used to route IO back to test sources
+    pub route_code: Option<String>,
+    /// Event tags if present
+    pub tags: Option<Vec<String>>,
+    /// When true indicates that this test (route_code + test_id) is individually runnable
+    pub runnable: bool,
+}
+
+impl Event {
+    /// Construct an event.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(status: TestStatus) -> EventBuilder {
+        EventBuilder(Self {
+            status,
+            test_id: None,
+            timestamp: None,
+            file: File::default(),
+            route_code: None,
+            tags: None,
+            runnable: false,
+        })
+    }
+
+    /// Write the event to a byte vector. The maximum size of a serialized event
+    /// is 4MiB.
+    ///
+    /// To avoid allocations, a single vector with reserved capacity can be used
+    /// and reused via the `Serializable` trait.
+    ///
+    /// The function can fail if the event is too large to serialize : Subunit
+    /// defines a 4MB limit. On failure, partial content may have been written.
+    pub fn to_vec(&self) -> GenResult<Vec<u8>> {
+        let size = self.wire_size()?.as_u32() as usize;
+        let mut buffer = Vec::with_capacity(size);
+        self.serialize(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn make_flags(&self) -> u16 {
+        let mut flags = EnumSet::new();
+
+        if self.timestamp.is_some() {
+            flags |= EventFeatures::Timestamp;
+        }
+        if self.test_id.is_some() {
+            flags |= EventFeatures::TestId;
+        }
+        if self.tags.is_some() {
+            flags |= EventFeatures::Tags;
+        }
+        if self.file.mime_type.is_some() {
+            flags |= EventFeatures::FileMimeType;
+        }
+        if self.file.file.is_some() {
+            flags |= EventFeatures::FileContent;
+        }
+        if self.file.eof {
+            flags |= EventFeatures::EndOfFile;
+        }
+        if self.route_code.is_some() {
+            flags |= EventFeatures::RoutingCode;
+        }
+        if self.runnable {
+            flags |= EventFeatures::Runnable;
+        }
+
+        let version = 0x2000_u16; // version 0x2
+
+        version | flags.as_repr() | self.status as u16
+    }
+
+    fn packet_length(base_length: u32) -> GenResult<SubunitNumber> {
+        // The length of the packet length is self-referential, so we can't
+        // simply serialise the length of all the other components. Instead, we allow extra space for the number of bytes required to encode the length of the packet itself.
+        match base_length {
+            0..=62 => 1_u32 + base_length,
+            63..=16381 => 2_u32 + base_length,
+            16382..=4194300 => 3_u32 + base_length, // == MAX_PACKET_LENGTH
+            _ => return Err(Error::TooLarge.into()),
+        }
+        .try_into()
+    }
+}
+
+impl Serializable for Event {
+    fn wire_size(&self) -> GenResult<SubunitNumber> {
+        //  PACKET = SIGNATURE FLAGS PACKET_LENGTH TIMESTAMP? TESTID? TAGS?
+        //           MIME? FILECONTENT? ROUTING_CODE? CRC32
+        let base_length = (dbg!(V2_SIGNATURE.wire_size()?.as_u32())
+            + dbg!(2) // flags u16
+            // + SubunitNumber(...).wire_size() // packet length- see below
+            + dbg!(self.timestamp.wire_size()?) // timestamp
+            + dbg!(self.test_id.wire_size()? )// test_id
+            + dbg!(self.tags.wire_size()? )// tags
+            + dbg!(self.file.wire_size()?) // file content
+            + dbg!(self.route_code.wire_size()?) // route code 
+            + dbg!(SubunitNumber::new(4_u32)?))?; // crc32
+
+        Self::packet_length(base_length.as_u32())
+    }
+
+    fn serialize<W: Write>(&self, out: &mut W) -> GenResult<()> {
+        //  PACKET = SIGNATURE FLAGS PACKET_LENGTH TIMESTAMP? TESTID? TAGS?
+        //           MIME? FILECONTENT? ROUTING_CODE? CRC32
+        // Hash while writing
+        let mut writer = Writer::new(out);
+        crate::constants::V2_SIGNATURE.serialize(&mut writer)?;
+        // TODO: make a flags struct to make this nicer?
+        let flags = self.make_flags();
+        writer.write_all(&flags.to_be_bytes())?;
+
+        let packet_length = self.wire_size()?;
+        packet_length.serialize(&mut writer)?;
+        self.timestamp.serialize(&mut writer)?;
+        self.test_id.serialize(&mut writer)?;
+        self.tags.serialize(&mut writer)?;
+        self.file.serialize(&mut writer)?;
+        self.route_code.serialize(&mut writer)?;
+
+        // Flush buffer into output and digest to calculate crc32
+        let checksum = writer.finalize();
+        out.write_all(&checksum.to_be_bytes())?;
+        Ok(())
+    }
+}
+
+impl Deserializable for Event {
+    fn required_bytes(bytes: &[u8]) -> GenResult<usize> {
+        //  PACKET = SIGNATURE FLAGS PACKET_LENGTH TIMESTAMP? TESTID? TAGS?
+        //           MIME? FILECONTENT? ROUTING_CODE? CRC32
+        let mut reader = Reader::new(bytes);
+        let signature = safe_read!(reader.read::<u8>()?);
+        if signature != V2_SIGNATURE {
+            return Err(Error::InvalidSignature.into());
+        }
+        let flags = safe_read!(reader.read::<u16>()?);
+        // TODO : wrapper type to avoid duplication?
+        if flags & 0xF000 != constants::VERSION2 {
+            return Err(Error::BadVersion(flags & 0xF00).into());
+        }
+        let _features = EnumSet::<EventFeatures>::from_repr_truncated(flags);
+        let packet_length = safe_read!(reader.read::<SubunitNumber>()?);
+        if packet_length.as_u32() > constants::MAX_PACKET_LENGTH {
+            return Err(Error::TooLarge.into());
+        }
+        if (packet_length.as_u32() as usize) < reader.bytes_read {
+            return Err(
+                Error::LengthTooSmall(packet_length.as_u32(), reader.bytes_read as u32).into(),
+            );
+        }
+        Ok(packet_length.as_u32() as usize)
+    }
+
+    fn deserialize(bytes: &[u8]) -> GenResult<(Self, usize)> {
+        //  PACKET = SIGNATURE FLAGS PACKET_LENGTH TIMESTAMP? TESTID? TAGS?
+        //           MIME? FILECONTENT? ROUTING_CODE? CRC32
+        let mut reader = Reader::new(bytes);
+        let signature = safe_de!(reader.read::<u8>()?);
+        if signature != V2_SIGNATURE {
+            return Err(Error::InvalidSignature.into());
+        }
+        let flags = safe_de!(reader.read::<u16>()?);
+        // TODO : wrapper type to avoid duplication?
+        if flags & 0xF000 != constants::VERSION2 {
+            return Err(Error::BadVersion(flags & 0xF00).into());
+        }
+        let status = TestStatus::from(flags);
+        let features = EnumSet::<EventFeatures>::from_repr_truncated(flags);
+        let packet_length = safe_de!(reader.read::<SubunitNumber>()?).as_u32() as usize;
+        if packet_length > constants::MAX_PACKET_LENGTH as usize {
+            return Err(Error::TooLarge.into());
+        }
+        if packet_length < reader.bytes_read {
+            return Err(
+                Error::LengthTooSmall(packet_length as u32, reader.bytes_read as u32).into(),
+            );
+        }
+        // Don't permit out of bound reads. From this point on, we don't
+        // pre-check the length of reads.
+        reader.set_slice_end(packet_length)?;
+        let mut result = Event {
+            status,
+            test_id: None,
+            timestamp: None,
+            file: File::default(),
+            route_code: None,
+            tags: None,
+            runnable: false,
+        };
+
+        // It is temping to iterate over the features, but the wire order iteration matters - TODO: see if that is possible
+
+        if features.contains(EventFeatures::Reserved) {
+            return Err(Error::Internal("Reserved feature".to_string()).into());
+        }
+        if features.contains(EventFeatures::Timestamp) {
+            let timestamp = safe_de!(reader.read_without_estimating::<Timestamp>()?);
+            result.timestamp = Some(timestamp);
+        }
+        if features.contains(EventFeatures::TestId) {
+            let test_id = safe_de!(reader.read_without_estimating::<String>()?);
+            result.test_id = Some(test_id);
+        }
+        if features.contains(EventFeatures::Tags) {
+            let tags = safe_de!(reader.read_without_estimating::<Vec<String>>()?);
+            result.tags = Some(tags);
+        }
+        if features.contains(EventFeatures::Runnable) {
+            result.runnable = true;
+        }
+        if features.contains(EventFeatures::EndOfFile) {
+            result.file.eof = true
+        }
+        // TODO: make safe_de reusable without hashing and push this down to the file struct
+        if features.contains(EventFeatures::FileMimeType) {
+            let mime = safe_de!(reader.read_without_estimating::<String>()?);
+            result.file.mime_type = Some(mime);
+        }
+        if features.contains(EventFeatures::FileContent) {
+            let name = safe_de!(reader.read_without_estimating::<String>()?);
+            let content = safe_de!(reader.read_without_estimating::<Vec<u8>>()?);
+            result.file.file = Some((name, content));
+        }
+        if features.contains(EventFeatures::RoutingCode) {
+            let route_code = safe_de!(reader.read_without_estimating::<String>()?);
+            result.route_code = Some(route_code);
+        }
+
+        let packet_crc32 = u32::from_be_bytes(
+            reader.bytes[reader.bytes_read..reader.bytes_read + 4]
+                .try_into()
+                .unwrap(),
+        );
+        let measured_crc32 = reader.finalize();
+
+        if measured_crc32 != packet_crc32 {
+            return Err(Error::CRC32Mismatch(measured_crc32, packet_crc32).into());
+        }
+
+        Ok((result, packet_length))
+    }
+}
+
+/// Helper to avoid some boilerplate in deserialization
+struct Reader<'a> {
+    bytes: &'a [u8],
+    bytes_read: usize,
+    hasher: Hasher,
+}
+
+impl<'a> Reader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self {
+            bytes,
+            bytes_read: 0,
+            hasher: Hasher::new(),
+        }
+    }
+
+    fn read<T>(&mut self) -> GenResult<Result<T, usize>>
+    where
+        T: Deserializable,
+    {
+        let required = T::required_bytes(&self.bytes[self.bytes_read..])?;
+        if required > self.bytes.len() {
+            return Ok(Err(required + self.bytes_read));
+        }
+        let val = T::deserialize(&self.bytes[self.bytes_read..])?;
+        self.hasher
+            .update(&self.bytes[self.bytes_read..self.bytes_read + val.1]);
+        self.bytes_read += val.1;
+        Ok(Ok(val.0))
+    }
+
+    /// read(), but trust that the length is correct and bounds checking will happen in deserialize.
+    fn read_without_estimating<T>(&mut self) -> GenResult<Result<T, usize>>
+    where
+        T: Deserializable,
+    {
+        let val = T::deserialize(&self.bytes[self.bytes_read..])?;
+        self.hasher
+            .update(&self.bytes[self.bytes_read..self.bytes_read + val.1]);
+        self.bytes_read += val.1;
+        Ok(Ok(val.0))
+    }
+
+    fn finalize(self) -> u32 {
+        self.hasher.finalize()
+    }
+
+    /// Sets the slice end to a given length: this prevents reading past the end of the length.
+    fn set_slice_end(&mut self, length: usize) -> GenResult<()> {
+        if length > self.bytes.len() {
+            return Err(Error::NotEnoughBytes.into());
+        }
+        self.bytes = &self.bytes[..length];
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use chrono::{DateTime, TimeZone, Utc};
+
+    use crate::{
+        deserialize::Deserializable,
+        serialize::Serializable,
+        types::{event::Event, teststatus::TestStatus},
+    };
+
+    #[test]
+    fn test_write_event() {
+        let event = Event::new(TestStatus::InProgress)
+            .test_id("A_test_id")
+            .datetime(Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap())
+            .unwrap()
+            .tag("tag_a")
+            .tag("tag_b")
+            .build();
+
+        let buffer = event.to_vec().unwrap();
+        let out_event = Event::deserialize(&buffer).unwrap().0;
+        assert_eq!(event, out_event);
+    }
+
+    #[test]
+    fn test_write_full_test_event_with_file_content() {
+        let event = Event::new(TestStatus::InProgress)
+            .test_id("A_test_id")
+            .datetime(Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap())
+            .unwrap()
+            .tag("tag_a")
+            .tag("tag_b")
+            .mime_type("text/plain;charset=utf8")
+            .file_content("stdout:''", b"stdout content")
+            .build();
+        let event_a = Event::new(TestStatus::Failed)
+            .test_id("A_test_id")
+            .datetime(Utc.with_ymd_and_hms(2014, 7, 8, 9, 12, 1).unwrap())
+            .unwrap()
+            .tag("tag_a")
+            .tag("tag_b")
+            .build();
+
+        let mut buffer = event.to_vec().unwrap();
+        event_a.serialize(&mut buffer).unwrap();
+
+        let mut offset = 0;
+        for event in [event, event_a].iter() {
+            let (parsed_event, length) = Event::deserialize(&buffer[offset..]).unwrap();
+            assert_eq!(*event, parsed_event);
+            offset += length;
+        }
+    }
+
+    #[test]
+    fn test_reference_values() {
+        #[track_caller]
+        fn assert_reference(event: Event, buffer: &[u8]) {
+            // We can parse the reference output
+            let (parsed, length) = Event::deserialize(buffer).unwrap();
+            assert_eq!(length, buffer.len());
+            assert_eq!(parsed, event);
+            // We can serialize and it matches the reference output
+            let serialized = event.to_vec().unwrap();
+            assert_eq!(serialized, buffer);
+        }
+
+        // Constants from the reference implementation
+        let enumerated: &[u8] = b"\xb3)\x01\x0c\x03foo\x08U_\x1b";
+        assert_reference(
+            Event::new(TestStatus::Enumeration)
+                .test_id("foo")
+                .runnable()
+                .build(),
+            enumerated,
+        );
+
+        let inprogress: &[u8] = b"\xb3)\x02\x0c\x03foo\x8e\xc1-\xb5";
+        assert_reference(
+            Event::new(TestStatus::InProgress)
+                .test_id("foo")
+                .runnable()
+                .build(),
+            inprogress,
+        );
+
+        let success: &[u8] = b"\xb3)\x03\x0c\x03fooE\x9d\xfe\x10";
+        assert_reference(
+            Event::new(TestStatus::Success)
+                .test_id("foo")
+                .runnable()
+                .build(),
+            success,
+        );
+
+        let uxsuccess: &[u8] = b"\xb3)\x04\x0c\x03fooX\x98\xce\xa8";
+        assert_reference(
+            Event::new(TestStatus::UnexpectedSuccess)
+                .test_id("foo")
+                .runnable()
+                .build(),
+            uxsuccess,
+        );
+
+        let skip: &[u8] = b"\xb3)\x05\x0c\x03foo\x93\xc4\x1d\r";
+        assert_reference(
+            Event::new(TestStatus::Skipped)
+                .test_id("foo")
+                .runnable()
+                .build(),
+            skip,
+        );
+
+        let fail: &[u8] = b"\xb3)\x06\x0c\x03foo\x15Po\xa3";
+        assert_reference(
+            Event::new(TestStatus::Failed)
+                .test_id("foo")
+                .runnable()
+                .build(),
+            fail,
+        );
+
+        let xfail: &[u8] = b"\xb3)\x07\x0c\x03foo\xde\x0c\xbc\x06";
+        assert_reference(
+            Event::new(TestStatus::ExpectedFailure)
+                .test_id("foo")
+                .runnable()
+                .build(),
+            xfail,
+        );
+
+        let eof: &[u8] = b"\xb3!\x10\x08S\x15\x88\xdc";
+        assert_reference(
+            Event::new(TestStatus::Undefined)
+                .end_of_file()
+                .runnable()
+                .build(),
+            eof,
+        );
+
+        let file_content: &[u8] = b"\xb3!@\x13\x06barney\x03wooA5\xe3\x8c";
+        assert_reference(
+            Event::new(TestStatus::Undefined)
+                .file_content("barney", b"woo")
+                .runnable()
+                .build(),
+            file_content,
+        );
+
+        let mime: &[u8] = b"\xb3! #\x1aapplication/foo; charset=1x3Q\x15";
+        assert_reference(
+            Event::new(TestStatus::Undefined)
+                .mime_type("application/foo; charset=1")
+                .runnable()
+                .build(),
+            mime,
+        );
+
+        let timestamp: &[u8] = b"\xb3+\x03\x13<\x17T\xcf\x80\xaf\xc8\x03barI\x96>-";
+        assert_reference(
+            Event::new(TestStatus::Success)
+                .test_id("bar")
+                .datetime(DateTime::from_timestamp(1008161999, 45000).unwrap())
+                .unwrap()
+                .runnable()
+                .build(),
+            timestamp,
+        );
+
+        let route_code: &[u8] = b"\xb3-\x03\x13\x03bar\x06source\x9cY9\x19";
+        assert_reference(
+            Event::new(TestStatus::Success)
+                .test_id("bar")
+                .route_code("source")
+                .runnable()
+                .build(),
+            route_code,
+        );
+
+        let runnable: &[u8] = b"\xb3(\x03\x0c\x03foo\xe3\xea\xf5\xa4";
+        assert_reference(
+            Event::new(TestStatus::Success).test_id("foo").build(),
+            runnable,
+        );
+
+        // Tags have no defined order in the protocol. At least today in the Rust implementation, they are ordered as given/observed.
+        let tag1: &[u8] = b"\xb3)\x80\x15\x03bar\x02\x03foo\x03barTHn\xb4";
+        assert_reference(
+            Event::new(TestStatus::Undefined)
+                .test_id("bar")
+                .tag("foo")
+                .tag("bar")
+                .runnable()
+                .build(),
+            tag1,
+        );
+
+        let tag2: &[u8] = b"\xb3)\x80\x15\x03bar\x02\x03bar\x03foo\xf8\xf1\x91o";
+        assert_reference(
+            Event::new(TestStatus::Undefined)
+                .test_id("bar")
+                .tag("bar")
+                .tag("foo")
+                .runnable()
+                .build(),
+            tag2,
+        );
+    }
+
+    #[test]
+    fn packet_length() {
+        assert_eq!(12, Event::packet_length(11).unwrap().as_u32());
+    }
+}

--- a/src/types/file.rs
+++ b/src/types/file.rs
@@ -1,0 +1,42 @@
+//! file handling support for subunit V2
+
+use crate::serialize::Serializable;
+
+/// A file event in Subunit V2 has a name, optional content, and an optional end of file marker. The files MIME type can
+/// also be specified. The wire format can represent these all as separate concepts, which leads to a little friction in
+/// the language bindings.
+///
+/// [Docs](https://github.com/testing-cabal/subunit/blob/fc698775674fcbdb9fcc8286d8358c7185647db4/README.rst?plain=1#L329)
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct File {
+    /// Optional MIME type.
+    pub mime_type: Option<String>,
+    /// Optional File name and content
+    pub file: Option<(String, Vec<u8>)>,
+    /// The end of file marker
+    pub eof: bool,
+}
+
+impl Serializable for File {
+    fn wire_size(&self) -> crate::GenResult<crate::types::number::SubunitNumber> {
+        self.mime_type.wire_size()? + self.file.wire_size()?
+        // EOF is serialised as a flag
+    }
+
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> crate::GenResult<()> {
+        self.mime_type.serialize(writer)?;
+        self.file.serialize(writer)?;
+        Ok(())
+    }
+}
+
+// TODO: move the file handling here, after Reader without hashing is usable.
+// impl Deserializable for File {
+//     fn required_bytes(_bytes: &[u8]) -> crate::GenResult<usize> {
+//         unimplemented!("File::required_bytes")
+//     }
+
+//     fn deserialize(bytes: &[u8]) -> crate::GenResult<(File, usize)> {
+//         unimplemented!("File::deserialize")
+//     }
+// }

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -1,0 +1,278 @@
+//! Helpers for number types.
+
+use std::{fmt::Debug, io::Write, ops::Add};
+
+use crate::{
+    constants::{self, NUMBER_KIND_MASK, NUMBER_VALUE_MASK},
+    deserialize::Deserializable,
+    serialize::Serializable,
+    Error, GenError, GenResult,
+};
+
+/// The concept of the type of the encoding of a number, stored in the 2 most
+/// significant bits of the number.
+///
+/// [Docs](https://github.com/testing-cabal/subunit/blob/fc698775674fcbdb9fcc8286d8358c7185647db4/README.rst?plain=1#L199)
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[repr(u8)]
+pub(crate) enum NumberType {
+    OneByte = 0b00000000,
+    TwoBytes = 0b01000000,
+    ThreeBytes = 0b10000000,
+    FourBytes = 0b11000000,
+}
+
+impl NumberType {
+    pub fn new(byte: u8) -> NumberType {
+        let number_type = byte & NUMBER_KIND_MASK;
+        match number_type >> 6 {
+            // 0b00, 1 octet
+            0 => NumberType::OneByte,
+            // 0b01, 2octets
+            1 => NumberType::TwoBytes,
+            // 0b10, 3 octets
+            2 => NumberType::ThreeBytes,
+            // 0b11, 4 octets
+            _ => NumberType::FourBytes,
+        }
+    }
+}
+
+/// A subunit wire protocol number
+///
+/// [Docs](https://github.com/testing-cabal/subunit/blob/fc698775674fcbdb9fcc8286d8358c7185647db4/README.rst?plain=1#L199)
+#[derive(Clone, Copy, PartialEq)]
+pub enum SubunitNumber {
+    /// A number that fits in one byte
+    OneByte([u8; 1]),
+    /// A number that fits in two bytes, in network order, with encoding mark.
+    TwoBytes([u8; 2]),
+    /// A number that fits in three bytes, in network order, with encoding mark.
+    ThreeBytes([u8; 3]),
+    /// A number that fits in four bytes, in network order, with encoding mark.
+    FourBytes([u8; 4]),
+}
+
+impl Debug for SubunitNumber {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SubunitNumber({} {:?})", self.as_u32(), self.as_bytes())
+    }
+}
+
+impl SubunitNumber {
+    pub fn new(value: u32) -> GenResult<Self> {
+        if value > constants::MAX_NUMBER_VALUE {
+            return Err(Error::TooLarge.into());
+        }
+        Ok(match value {
+            /* 2^(8-2) */ 0..=63 => SubunitNumber::OneByte([value as u8]),
+            /* 2^(16-2) */
+            64..=16383 => {
+                let mut bytes = (value as u16).to_be_bytes();
+                bytes[0] |= NumberType::TwoBytes as u8;
+                SubunitNumber::TwoBytes(bytes)
+            }
+            /* 2^(24-2) */
+            16384..=4194303 => {
+                let mut bytes = value.to_be_bytes();
+                bytes[1] |= NumberType::ThreeBytes as u8;
+                SubunitNumber::ThreeBytes(bytes[1..].try_into().unwrap())
+            }
+            /* 2^(32-2) */
+            _ => {
+                let mut bytes = value.to_be_bytes();
+                bytes[0] |= NumberType::FourBytes as u8;
+                SubunitNumber::FourBytes(bytes)
+            }
+        })
+    }
+
+    pub fn as_u32(&self) -> u32 {
+        match self {
+            SubunitNumber::OneByte(value) => u32::from(value[0]),
+            SubunitNumber::TwoBytes(value) => {
+                u32::from(value[0] & NUMBER_VALUE_MASK) << 8 | u32::from(value[1])
+            }
+            SubunitNumber::ThreeBytes(value) => {
+                u32::from(value[0] & NUMBER_VALUE_MASK) << 16
+                    | u32::from(value[1]) << 8
+                    | u32::from(value[2])
+            }
+            SubunitNumber::FourBytes(value) => {
+                u32::from(value[0] & NUMBER_VALUE_MASK) << 24
+                    | u32::from(value[1]) << 16
+                    | u32::from(value[2]) << 8
+                    | u32::from(value[3])
+            }
+        }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            SubunitNumber::OneByte(value) => value,
+            SubunitNumber::TwoBytes(value) => value,
+            SubunitNumber::ThreeBytes(value) => value,
+            SubunitNumber::FourBytes(value) => value,
+        }
+    }
+}
+
+impl TryFrom<u32> for SubunitNumber {
+    type Error = GenError;
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        SubunitNumber::new(value)
+    }
+}
+
+impl TryFrom<usize> for SubunitNumber {
+    type Error = GenError;
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        SubunitNumber::new(value.try_into()?)
+    }
+}
+
+impl From<SubunitNumber> for u32 {
+    fn from(value: SubunitNumber) -> Self {
+        value.as_u32()
+    }
+}
+
+impl Add<SubunitNumber> for u32 {
+    type Output = GenResult<SubunitNumber>;
+    fn add(self, other: SubunitNumber) -> Self::Output {
+        let result = self.checked_add(other.as_u32());
+        match result {
+            Some(value) => Ok(value.try_into()?),
+            None => Err(Error::TooLarge.into()),
+        }
+    }
+}
+
+impl Add<SubunitNumber> for usize {
+    type Output = GenResult<SubunitNumber>;
+    fn add(self, other: SubunitNumber) -> Self::Output {
+        let result = self.checked_add(other.as_u32() as usize);
+        match result {
+            Some(value) => Ok(value.try_into()?),
+            None => Err(Error::TooLarge.into()),
+        }
+    }
+}
+impl Add<SubunitNumber> for GenResult<SubunitNumber> {
+    type Output = GenResult<SubunitNumber>;
+    fn add(self, other: SubunitNumber) -> Self::Output {
+        let result = self?.as_u32().checked_add(other.as_u32());
+        match result {
+            Some(value) => Ok(value.try_into()?),
+            None => Err(Error::TooLarge.into()),
+        }
+    }
+}
+
+impl Add for SubunitNumber {
+    type Output = GenResult<SubunitNumber>;
+    fn add(self, other: SubunitNumber) -> Self::Output {
+        let result = self.as_u32().checked_add(other.as_u32());
+        match result {
+            Some(value) => Ok(value.try_into()?),
+            None => Err(Error::TooLarge.into()),
+        }
+    }
+}
+
+impl Serializable for SubunitNumber {
+    fn wire_size(&self) -> GenResult<SubunitNumber> {
+        match self.as_u32() {
+            0..=63 => SubunitNumber::new(1),
+            64..=16383 => SubunitNumber::new(2),
+            16384..=4194303 => SubunitNumber::new(3),
+            _ => SubunitNumber::new(4),
+        }
+    }
+
+    fn serialize<W: Write>(&self, out: &mut W) -> GenResult<()> {
+        out.write_all(self.as_bytes())?;
+        Ok(())
+    }
+}
+
+impl Deserializable for SubunitNumber {
+    fn required_bytes(bytes: &[u8]) -> GenResult<usize> {
+        if bytes.is_empty() {
+            return Ok(1);
+        }
+        Ok(match NumberType::new(bytes[0]) {
+            NumberType::OneByte => 1,
+            NumberType::TwoBytes => 2,
+            NumberType::ThreeBytes => 3,
+            NumberType::FourBytes => 4,
+        })
+    }
+
+    fn deserialize(bytes: &[u8]) -> GenResult<(SubunitNumber, usize)> {
+        if bytes.is_empty() {
+            return Err(Error::NotEnoughBytes.into());
+        }
+        let size = SubunitNumber::required_bytes(bytes)?;
+        if bytes.len() < size {
+            return Err(Error::NotEnoughBytes.into());
+        }
+        let b = &bytes[..size];
+        // The unwraps are infallible - the size is matched
+        Ok((
+            match NumberType::new(bytes[0]) {
+                NumberType::OneByte => SubunitNumber::OneByte(b.try_into().unwrap()),
+                NumberType::TwoBytes => SubunitNumber::TwoBytes(b.try_into().unwrap()),
+                NumberType::ThreeBytes => SubunitNumber::ThreeBytes(b.try_into().unwrap()),
+                NumberType::FourBytes => SubunitNumber::FourBytes(b.try_into().unwrap()),
+            },
+            size,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NumberType;
+    use super::SubunitNumber;
+
+    #[test]
+    fn test_number_type() {
+        assert_eq!(NumberType::new(0b00000000), NumberType::OneByte);
+        assert_eq!(NumberType::new(0b00111111), NumberType::OneByte);
+        assert_eq!(NumberType::new(0b01000000), NumberType::TwoBytes);
+        assert_eq!(NumberType::new(0b01111111), NumberType::TwoBytes);
+        assert_eq!(NumberType::new(0b10000000), NumberType::ThreeBytes);
+        assert_eq!(NumberType::new(0b10111111), NumberType::ThreeBytes);
+        assert_eq!(NumberType::new(0b11000000), NumberType::FourBytes);
+        assert_eq!(NumberType::new(0b11111111), NumberType::FourBytes);
+    }
+
+    #[test]
+    fn test_subunit_number() {
+        let number = SubunitNumber::new(0).unwrap();
+        assert_eq!(number.as_u32(), 0);
+        assert_eq!(number.as_bytes(), &[0]);
+        let number = SubunitNumber::new(63).unwrap();
+        assert_eq!(number.as_u32(), 63);
+        assert_eq!(number.as_bytes(), &[0b00111111]);
+        let number = SubunitNumber::new(64).unwrap();
+        assert_eq!(number.as_u32(), 64);
+        assert_eq!(number.as_bytes(), &[0b01000000, 64]);
+        let number = SubunitNumber::new(16383).unwrap();
+        assert_eq!(number.as_u32(), 16383);
+        assert_eq!(number.as_bytes(), &[0b01111111, 255]);
+        let number = SubunitNumber::new(16384).unwrap();
+        assert_eq!(number.as_u32(), 16384);
+        assert_eq!(number.as_bytes(), &[0b10000000, 64, 0]);
+        let number = SubunitNumber::new(4194303).unwrap();
+        assert_eq!(number.as_u32(), 4194303);
+        assert_eq!(number.as_bytes(), &[0b10111111, 255, 255]);
+        let number = SubunitNumber::new(4194304).unwrap();
+        assert_eq!(number.as_u32(), 4194304);
+        assert_eq!(number.as_bytes(), &[0b11000000, 64, 0, 0]);
+        let number = SubunitNumber::new(0x3FFFFFFF).unwrap();
+        assert_eq!(number.as_u32(), 0x3FFFFFFF);
+        assert_eq!(number.as_bytes(), &[0b11111111, 255, 255, 255]);
+    }
+}

--- a/src/types/stream.rs
+++ b/src/types/stream.rs
@@ -1,0 +1,104 @@
+//! Support for streams of subunit events.
+
+use crate::{
+    constants::V2_SIGNATURE, deserialize::Deserializable, types::event::Event, Error, GenError,
+    GenResult,
+};
+
+/// Newtype to hold the implementation of a UTF8 variable length encoding. Not 'char' because surrogates are included.
+/// Perhaps it will be hidden in future.
+#[derive(Debug)]
+pub struct UTF8VariableLength {
+    pub bytes: Vec<u8>,
+}
+
+impl Deserializable for UTF8VariableLength {
+    fn required_bytes(bytes: &[u8]) -> GenResult<usize> {
+        if bytes.is_empty() {
+            return Ok(1);
+        }
+        // Single octet codepoint
+        if bytes[0] & 0b10000000 == 0 {
+            return Ok(1);
+        }
+        // Continuation byte at start of sequence
+        if bytes[0] & 0b01000000 == 0 {
+            return Err(Error::InvalidUTF8Sequence.into());
+        }
+        // Two octet codepoint
+        if bytes[0] & 0b00100000 == 0 {
+            return Ok(2);
+        }
+        // Three octet codepoint
+        if bytes[0] & 0b00010000 == 0 {
+            return Ok(3);
+        }
+        // Four octet codepoint
+        if bytes[0] & 0b00001000 == 0 {
+            return Ok(4);
+        }
+        // 5 leading 1's? What is 5 leading 1's?
+        Err(Error::InvalidUTF8Sequence.into())
+    }
+
+    fn deserialize(bytes: &[u8]) -> GenResult<(Self, usize)> {
+        let length = Self::required_bytes(bytes)?;
+        Ok((
+            UTF8VariableLength {
+                bytes: bytes[..length].to_vec(),
+            },
+            length,
+        ))
+    }
+}
+
+/// Items in a subunit stream
+#[derive(Debug)]
+pub enum ScannedItem {
+    /// Non-event data following the UTF8 variable length encoding. May not actually be valid UTF8.
+    UTF8chars(UTF8VariableLength),
+    /// A subunit event
+    Event(Event),
+    /// Bytes that that are neither UTF8 variable-length encoded nor a valid
+    /// Subunit packet. Could be: interrupted bytes of either at the end of a
+    /// stream, striped and corrupted data, or a Subunit packet with a bad checksum
+    Unknown(Vec<u8>, GenError),
+}
+
+impl Deserializable for ScannedItem {
+    fn required_bytes(bytes: &[u8]) -> GenResult<usize> {
+        Event::required_bytes(bytes).or_else(|_| UTF8VariableLength::required_bytes(bytes))
+    }
+
+    fn deserialize(bytes: &[u8]) -> GenResult<(Self, usize)> {
+        // TODO: likely the unknown case is not handled thoroughly enough: we should fuzz this.
+        if bytes.is_empty() {
+            return Err(Error::NotEnoughBytes.into());
+        }
+        if bytes[0] == V2_SIGNATURE {
+            match Event::deserialize(bytes) {
+                Ok((event, used)) => Ok((ScannedItem::Event(event), used)),
+                Err(e) => {
+                    // In the normal codepath, hitting deserialize implies required_bytes succeeded.
+                    let packet_length = Event::required_bytes(bytes)?;
+                    // Probably a corrupt packet, but we can't know how much is corrupt.
+                    Ok((
+                        ScannedItem::Unknown(bytes[..packet_length].to_vec(), e),
+                        packet_length,
+                    ))
+                }
+            }
+        } else {
+            match UTF8VariableLength::required_bytes(bytes) {
+                Ok(required) => {
+                    let (utf8, used) = UTF8VariableLength::deserialize(&bytes[..required])?;
+                    Ok((ScannedItem::UTF8chars(utf8), used))
+                }
+                Err(e) => {
+                    // How much is corrupt / unknowable isn't known, so take one byte
+                    Ok((ScannedItem::Unknown(bytes[..1].to_vec(), e), 1))
+                }
+            }
+        }
+    }
+}

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,0 +1,84 @@
+//! Subunit timestamps
+
+use std::io::Write;
+
+use chrono::{DateTime, Utc};
+
+use crate::{
+    deserialize::Deserializable, serialize::Serializable, types::number::SubunitNumber, Error,
+    GenError, GenResult,
+};
+
+/// Subunit timestamps are UTC time since epoch with a u32 seconds component and
+/// a SubunitNumber nanoseconds component.
+///
+/// [Docs](https://github.com/testing-cabal/subunit/blob/fc698775674fcbdb9fcc8286d8358c7185647db4/README.rst?plain=1#L315)
+#[derive(Debug, Clone, PartialEq)]
+pub struct Timestamp {
+    /// The seconds component of the timestamp
+    pub seconds: u32,
+    /// The nanoseconds component of the timestamp
+    pub nanoseconds: SubunitNumber,
+}
+
+impl Serializable for Timestamp {
+    fn wire_size(&self) -> GenResult<SubunitNumber> {
+        //  TIMESTAMP = SECONDS NANOS
+        self.seconds.wire_size()? + self.nanoseconds.wire_size()?
+    }
+
+    fn serialize<W: Write>(&self, out: &mut W) -> GenResult<()> {
+        self.seconds.serialize(out)?;
+        self.nanoseconds.serialize(out)
+    }
+}
+
+impl Deserializable for Timestamp {
+    fn required_bytes(bytes: &[u8]) -> GenResult<usize> {
+        //  TIMESTAMP = SECONDS NANOS
+        let required = 5;
+        if bytes.len() < required {
+            return Ok(required);
+        }
+        let required = SubunitNumber::required_bytes(&bytes[4..5])?;
+        // The length is the 4 for the u32 in seconds + the variable length nanos
+        Ok(4 + required)
+    }
+
+    fn deserialize(bytes: &[u8]) -> GenResult<(Timestamp, usize)> {
+        let required = Timestamp::required_bytes(bytes)?;
+        if bytes.len() < required {
+            return Err(Error::NotEnoughBytes.into());
+        }
+        // infallible via guard above
+        let seconds = u32::from_be_bytes(bytes[..4].try_into().unwrap());
+        let nanoseconds = SubunitNumber::deserialize(&bytes[4..required])?.0;
+        Ok((
+            Timestamp {
+                seconds,
+                nanoseconds,
+            },
+            required,
+        ))
+    }
+}
+
+impl TryFrom<DateTime<Utc>> for Timestamp {
+    type Error = GenError;
+    fn try_from(dt: DateTime<Utc>) -> GenResult<Self> {
+        let seconds = dt.timestamp() as u32;
+        let nanoseconds = dt.timestamp_subsec_nanos().try_into()?;
+        Ok(Self {
+            seconds,
+            nanoseconds,
+        })
+    }
+}
+
+impl TryFrom<Timestamp> for DateTime<Utc> {
+    type Error = GenError;
+    fn try_from(ts: Timestamp) -> GenResult<Self> {
+        DateTime::from_timestamp(ts.seconds as i64, ts.nanoseconds.into())
+            .ok_or_else(|| Error::InvalidTimestamp(ts.seconds, ts.nanoseconds.into()).into())
+    }
+}


### PR DESCRIPTION
- optional dependency on async-stream, tokio and
  tokio-stream for async parsing
- a new push parser that operates on &[u8] and does not perform IO
- new sync module that has an Iterator for sync parsing which will use
  only as much memory as needed to parse the input
- CRC32 validation added

Bug fixes:
- support for all flags
- low-level support for files larger than 4MB (file reassembly /
  streaming can be built on top of the primitive, but is not yet built)

Closes: #15 
Closes: #5 