### PR TITLE
Fix bug in Scanner::next() that prevented reading data

### DIFF
--- a/src/io/sync.rs
+++ b/src/io/sync.rs
@@ -11,17 +11,22 @@ pub trait WriteInto {
 }
 
 /// Look for subunit events in an input stream.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct Scanner<R> {
     buffer: VecDeque<u8>,
     reader: R,
+    read_buf: Box<[u8; 4096]>,
 }
 
 /// Iterate over a Readable, yielding the contents as `ScannedItems`.
 pub fn iter_stream<R: Read>(reader: R) -> impl Iterator<Item = GenResult<ScannedItem>> {
     // Maximum buffer needed to process subunit packets is 4MB
     let buffer = VecDeque::<u8>::with_capacity(4 * 1024 * 1024);
-    Scanner { buffer, reader }
+    Scanner {
+        buffer,
+        reader,
+        read_buf: Box::new([0u8; 4096]),
+    }
 }
 
 impl<R> Iterator for Scanner<R>
@@ -31,15 +36,24 @@ where
     type Item = GenResult<ScannedItem>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let buf = self.buffer.make_contiguous();
-        let mut required_bytes = match ScannedItem::required_bytes(buf) {
-            Ok(v) => v,
-            Err(e) => return Some(Err(e)),
-        };
-        while buf.len() < required_bytes {
-            match self.reader.read(buf) {
+        loop {
+            let buf = self.buffer.make_contiguous();
+            let required_bytes = match ScannedItem::required_bytes(buf) {
+                Ok(v) => v,
+                Err(e) => return Some(Err(e)),
+            };
+
+            if buf.len() >= required_bytes {
+                // We have enough data - parse it
+                break;
+            }
+
+            // Need to read more data from the reader
+            // Use the reusable read buffer to avoid allocations
+            match self.reader.read(&mut self.read_buf[..]) {
                 Ok(0) => {
-                    if buf.is_empty() {
+                    // EOF reached
+                    if self.buffer.is_empty() {
                         return None;
                     }
                     // By definition, we have a partial packet or partial codepoint
@@ -48,16 +62,16 @@ where
                         Error::InvalidUTF8Sequence.into(),
                     )));
                 }
-                Ok(_) => (), // Might not be enough read yet
+                Ok(n) => {
+                    // Extend buffer with the bytes we actually read
+                    self.buffer.extend(&self.read_buf[..n]);
+                }
                 Err(e) => return Some(Err(e.into())),
             }
-            required_bytes = match ScannedItem::required_bytes(buf) {
-                Ok(v) => v,
-                Err(e) => return Some(Err(e)),
-            };
         }
 
         // Now we have enough data to do something with it.
+        let buf = self.buffer.make_contiguous();
 
         // TODO: scan rapidly and collect all UTF8 text in one go rather than depending on the optimiser to make it
         // efficient.
@@ -69,6 +83,8 @@ where
             Err(e) => {
                 // We know from the loop above that we had enough bytes, and this is not IO: some form of junk.
                 // We have an invalid char or failed crc32 or similar.
+                let buf = self.buffer.make_contiguous();
+                let required_bytes = ScannedItem::required_bytes(buf).unwrap_or(1);
                 Some(Ok(ScannedItem::Unknown(
                     self.buffer.drain(..required_bytes).collect(),
                     e,
@@ -124,14 +140,36 @@ mod tests {
         let mut buffer = event.to_vec().unwrap();
         event_a.serialize(&mut buffer).unwrap();
 
+        let mut count = 0;
         for (parsed_event, event) in
             sync::iter_stream(Cursor::new(&buffer)).zip([event, event_a].iter())
         {
+            count += 1;
             let parsed_event = parsed_event.unwrap();
             let ScannedItem::Event(parsed_event) = parsed_event else {
                 panic!("Expected event, got {:?}", parsed_event);
             };
             assert_eq!(*event, parsed_event);
         }
+        assert_eq!(count, 2, "Expected to read 2 events, got {}", count);
+    }
+
+    #[test]
+    fn test_scanner_reads_owned_cursor() {
+        // This test exposes the bug: Scanner fails when given ownership of the Cursor
+        // (as opposed to borrowing it like the test above)
+        let event = Event::new(TestStatus::Success).test_id("test").build();
+        let buffer = event.to_vec().unwrap();
+
+        // Pass owned Cursor - this should work but doesn't due to Scanner bug
+        let mut count = 0;
+        for item in sync::iter_stream(Cursor::new(buffer)) {
+            let item = item.unwrap();
+            if matches!(item, ScannedItem::Event(_)) {
+                count += 1;
+            }
+        }
+
+        assert_eq!(count, 1, "Expected 1 event, got {}", count);
     }
 }


### PR DESCRIPTION
Bug:
Scanner::next() was calling self.reader.read(buf) where buf was the result of make_contiguous(), which returns existing buffered data, not a writable buffer for new data. When the buffer started empty, buf was an empty slice, read() returned Ok(0), and the scanner immediately returned None without reading any data.

Example that wouldn't work:
  let event = Event::new(TestStatus::Success).test_id("test").build();
  let buffer = event.to_vec().unwrap();

  for item in iter_stream(Cursor::new(buffer)) {
      // This loop would never execute - scanner returns None immediately
  }

The scanner would return 0 events instead of 1, because it never actually read data from the Cursor.