### PR TITLE
Fix panic on malformed packets and improve test coverage

### DIFF
--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -109,3 +109,150 @@ impl Deserializable for Vec<String> {
         Ok((result, offset))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serialize::Serializable;
+
+    #[test]
+    fn test_u8_deserialize_empty() {
+        let result = u8::deserialize(&[]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_u8_deserialize_ok() {
+        let (val, size) = u8::deserialize(&[0x42]).unwrap();
+        assert_eq!(val, 0x42);
+        assert_eq!(size, 1);
+    }
+
+    #[test]
+    fn test_u16_deserialize_empty() {
+        let result = u16::deserialize(&[]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_u16_deserialize_one_byte() {
+        let result = u16::deserialize(&[0x01]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_u16_deserialize_ok() {
+        let (val, size) = u16::deserialize(&[0x01, 0x02]).unwrap();
+        assert_eq!(val, 0x0102);
+        assert_eq!(size, 2);
+    }
+
+    #[test]
+    fn test_string_required_bytes_empty() {
+        // Empty input: needs at least 1 byte for the length prefix
+        let required = String::required_bytes(&[]).unwrap();
+        assert_eq!(required, 1);
+    }
+
+    #[test]
+    fn test_string_required_bytes_with_length() {
+        // Length prefix says 3 bytes of content, using 1-byte encoding
+        // So total = 1 (length prefix) + 3 (content) = 4
+        let required = String::required_bytes(&[3, b'a', b'b', b'c']).unwrap();
+        assert_eq!(required, 4);
+    }
+
+    #[test]
+    fn test_string_required_bytes_just_length_prefix() {
+        // Exactly 1 byte: the length prefix itself (value=5)
+        // bytes.len() == required (1 == 1), so the < check passes and we proceed
+        // to parse the number and return 1 + 5 = 6
+        // If mutated to <=, it would return 1 early instead of 6
+        let required = String::required_bytes(&[5]).unwrap();
+        assert_eq!(required, 6);
+    }
+
+    #[test]
+    fn test_string_required_bytes_two_byte_length() {
+        // 2-byte length prefix for value 100: 0x40 | (100 >> 8), 100 & 0xFF = [0x40, 0x64]
+        let num = SubunitNumber::new(100).unwrap();
+        let mut buf = Vec::new();
+        num.serialize(&mut buf).unwrap();
+        buf.extend(vec![b'x'; 100]);
+        let required = String::required_bytes(&buf).unwrap();
+        assert_eq!(required, 102); // 2 (length prefix) + 100 (content)
+    }
+
+    #[test]
+    fn test_string_deserialize_roundtrip() {
+        let original = "hello world".to_string();
+        let mut buf = Vec::new();
+        original.serialize(&mut buf).unwrap();
+        let (deserialized, size) = String::deserialize(&buf).unwrap();
+        assert_eq!(deserialized, original);
+        assert_eq!(size, buf.len());
+    }
+
+    #[test]
+    fn test_string_deserialize_invalid_utf8() {
+        // Length prefix says 2 bytes, followed by invalid UTF-8
+        let buf = [2, 0xFF, 0xFE];
+        let result = String::deserialize(&buf);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_vec_u8_deserialize_empty_input() {
+        let result = Vec::<u8>::deserialize(&[]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_vec_u8_deserialize_truncated() {
+        // Length prefix says 5 bytes but only 2 are provided
+        let buf = [5, b'a', b'b'];
+        let result = Vec::<u8>::deserialize(&buf);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_vec_u8_deserialize_ok() {
+        let buf = [3, b'a', b'b', b'c'];
+        let (val, size) = Vec::<u8>::deserialize(&buf).unwrap();
+        assert_eq!(val, vec![b'a', b'b', b'c']);
+        assert_eq!(size, 4);
+    }
+
+    #[test]
+    fn test_vec_u8_deserialize_exact_length() {
+        // Length prefix says 1 byte, exactly 1 byte of content follows
+        // total = 1 (length prefix) + 1 (content) = 2
+        // This catches + -> - (would check bytes.len() < 1 - 1 = 0, passes incorrectly for empty)
+        // and + -> * (would check bytes.len() < 1 * 1 = 1, which is wrong)
+        let buf = [1, b'x'];
+        let (val, size) = Vec::<u8>::deserialize(&buf).unwrap();
+        assert_eq!(val, vec![b'x']);
+        assert_eq!(size, 2);
+    }
+
+    #[test]
+    fn test_vec_u8_deserialize_missing_one_byte() {
+        // Length says 3, but only 2 bytes of content (total 3 bytes, need 4)
+        let buf = [3, b'a', b'b'];
+        let result = Vec::<u8>::deserialize(&buf);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_vec_u8_roundtrip() {
+        let original = vec![1u8, 2, 3, 4, 5];
+        let as_tuple = ("name".to_string(), original.clone());
+        let mut buf = Vec::new();
+        as_tuple.serialize(&mut buf).unwrap();
+        // Deserialize the string first, then the vec
+        let (name, name_size) = String::deserialize(&buf).unwrap();
+        assert_eq!(name, "name");
+        let (val, _) = Vec::<u8>::deserialize(&buf[name_size..]).unwrap();
+        assert_eq!(val, original);
+    }
+}

--- a/src/io/async.rs
+++ b/src/io/async.rs
@@ -142,6 +142,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(results.len(), 3);
+        for item in &results {
+            assert!(
+                matches!(item, ScannedItem::Event(_)),
+                "Expected Event, got {:?}",
+                item
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,3 +109,28 @@ impl Debug for Error {
 
 type GenError = Box<dyn std::error::Error>;
 type GenResult<T> = Result<T, GenError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_max_packet_length() {
+        assert_eq!(constants::MAX_PACKET_LENGTH, 4_194_304);
+    }
+
+    #[test]
+    fn test_error_debug_uses_display() {
+        let err = Error::TooLarge;
+        assert_eq!(format!("{:?}", err), "Value is too large to encode");
+
+        let err = Error::NotEnoughBytes;
+        assert_eq!(format!("{:?}", err), "Not enough bytes");
+
+        let err = Error::LengthTooSmall(10, 20);
+        assert_eq!(
+            format!("{:?}", err),
+            "Invalid packet header: size 10 < header size 20"
+        );
+    }
+}

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -147,3 +147,34 @@ where
         self.buffer.flush()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    struct FlushTracker {
+        flushed: bool,
+    }
+
+    impl Write for FlushTracker {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.flushed = true;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_writer_flush() {
+        let mut tracker = FlushTracker { flushed: false };
+        {
+            let mut writer = Writer::new(&mut tracker);
+            writer.write_all(b"hello").unwrap();
+            writer.flush().unwrap();
+        }
+        assert!(tracker.flushed);
+    }
+}

--- a/src/types/event.rs
+++ b/src/types/event.rs
@@ -260,10 +260,12 @@ impl Deserializable for Event {
         if packet_length.as_u32() > constants::MAX_PACKET_LENGTH {
             return Err(Error::TooLarge.into());
         }
-        if (packet_length.as_u32() as usize) < reader.bytes_read {
-            return Err(
-                Error::LengthTooSmall(packet_length.as_u32(), reader.bytes_read as u32).into(),
-            );
+        if (packet_length.as_u32() as usize) < reader.bytes_read + 4 {
+            return Err(Error::LengthTooSmall(
+                packet_length.as_u32(),
+                reader.bytes_read as u32 + 4,
+            )
+            .into());
         }
         Ok(packet_length.as_u32() as usize)
     }
@@ -287,9 +289,9 @@ impl Deserializable for Event {
         if packet_length > constants::MAX_PACKET_LENGTH as usize {
             return Err(Error::TooLarge.into());
         }
-        if packet_length < reader.bytes_read {
+        if packet_length < reader.bytes_read + 4 {
             return Err(
-                Error::LengthTooSmall(packet_length as u32, reader.bytes_read as u32).into(),
+                Error::LengthTooSmall(packet_length as u32, reader.bytes_read as u32 + 4).into(),
             );
         }
         // Don't permit out of bound reads. From this point on, we don't
@@ -646,6 +648,195 @@ mod tests {
 
     #[test]
     fn packet_length() {
+        // 1-byte length range: 0..=62
         assert_eq!(12, Event::packet_length(11).unwrap().as_u32());
+        assert_eq!(63, Event::packet_length(62).unwrap().as_u32());
+        // 2-byte length range: 63..=16381
+        assert_eq!(65, Event::packet_length(63).unwrap().as_u32());
+        assert_eq!(16383, Event::packet_length(16381).unwrap().as_u32());
+        // 3-byte length range: 16382..=4194300
+        assert_eq!(16385, Event::packet_length(16382).unwrap().as_u32());
+        assert_eq!(4194303, Event::packet_length(4194300).unwrap().as_u32());
+        // Too large
+        assert!(Event::packet_length(4194301).is_err());
+    }
+
+    #[test]
+    fn test_deserialize_bad_version() {
+        // Craft a packet with bad version (0x3000 instead of 0x2000)
+        let mut buf: Vec<u8> = vec![0xb3]; // signature
+        buf.extend_from_slice(&0x3003_u16.to_be_bytes()); // bad version + flags
+        buf.push(0x08); // packet length = 8
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // crc32 placeholder
+
+        let err = Event::deserialize(&buf).unwrap_err();
+        // Error uses flags & 0xF00 mask, so 0x3003 & 0xF00 = 0x0
+        assert_eq!(format!("{}", err), "Bad version 0x0");
+    }
+
+    #[test]
+    fn test_required_bytes_bad_version() {
+        let mut buf: Vec<u8> = vec![0xb3]; // signature
+        buf.extend_from_slice(&0x3003_u16.to_be_bytes()); // bad version
+        buf.push(0x08); // packet length
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // padding
+
+        let err = Event::required_bytes(&buf).unwrap_err();
+        assert_eq!(format!("{}", err), "Bad version 0x0");
+    }
+
+    #[test]
+    fn test_required_bytes_too_few_bytes() {
+        // Only signature, not enough for flags
+        let buf: Vec<u8> = vec![0xb3];
+        let required = Event::required_bytes(&buf).unwrap();
+        assert_eq!(required, 3); // needs at least signature + flags
+    }
+
+    #[test]
+    fn test_deserialize_packet_length_too_small() {
+        // Craft a packet where declared length < header bytes read
+        let mut buf: Vec<u8> = vec![0xb3]; // signature
+        buf.extend_from_slice(&0x2003_u16.to_be_bytes()); // valid version + status
+        buf.push(0x02); // packet length = 2, but we already read 4 bytes (sig + flags + len)
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // crc32
+
+        let err = Event::deserialize(&buf).unwrap_err();
+        let msg = format!("{}", err);
+        assert_eq!(msg, "Invalid packet header: size 2 < header size 8");
+    }
+
+    #[test]
+    fn test_required_bytes_packet_length_too_small() {
+        let mut buf: Vec<u8> = vec![0xb3]; // signature
+        buf.extend_from_slice(&0x2003_u16.to_be_bytes()); // valid version
+        buf.push(0x02); // packet length = 2 < header
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // padding
+
+        let err = Event::required_bytes(&buf).unwrap_err();
+        let msg = format!("{}", err);
+        assert_eq!(msg, "Invalid packet header: size 2 < header size 8");
+    }
+
+    #[test]
+    fn test_required_bytes_packet_length_equals_minimum() {
+        // Minimum valid packet: sig(1) + flags(2) + len(1) + crc(4) = 8
+        // packet_length == bytes_read + 4 == 8: should NOT error
+        let mut buf: Vec<u8> = vec![0xb3]; // signature
+        buf.extend_from_slice(&0x2000_u16.to_be_bytes()); // valid version, no features
+        buf.push(0x08); // packet length = 8 = header(4) + crc(4)
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // crc placeholder
+
+        let required = Event::required_bytes(&buf).unwrap();
+        assert_eq!(required, 8);
+    }
+
+    #[test]
+    fn test_required_bytes_packet_length_too_small_for_crc() {
+        // packet_length = 4 (just header, no room for CRC) → should error
+        let mut buf: Vec<u8> = vec![0xb3]; // signature
+        buf.extend_from_slice(&0x2000_u16.to_be_bytes()); // valid version
+        buf.push(0x04); // packet length = 4, too small for header + crc
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+
+        let err = Event::required_bytes(&buf).unwrap_err();
+        let msg = format!("{}", err);
+        assert_eq!(msg, "Invalid packet header: size 4 < header size 8");
+    }
+
+    #[test]
+    fn test_deserialize_packet_length_equals_minimum() {
+        // Minimum valid packet: sig(1) + flags(2) + len(1) + crc(4) = 8
+        let mut buf: Vec<u8> = vec![0xb3]; // signature
+        buf.extend_from_slice(&0x2000_u16.to_be_bytes()); // valid version, no features, status=Undefined
+        buf.push(0x08); // packet length = 8 (header + crc32)
+
+        // Calculate the correct CRC32 for the header bytes
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(&buf);
+        let crc = hasher.finalize();
+        buf.extend_from_slice(&crc.to_be_bytes());
+
+        let (event, size) = Event::deserialize(&buf).unwrap();
+        assert_eq!(size, 8);
+        assert_eq!(event.status, TestStatus::Undefined);
+    }
+
+    #[test]
+    fn test_deserialize_packet_length_too_small_for_crc() {
+        // packet_length = 4 (no room for CRC) used to panic, now returns error
+        let mut buf: Vec<u8> = vec![0xb3]; // signature
+        buf.extend_from_slice(&0x2000_u16.to_be_bytes()); // valid version
+        buf.push(0x04); // packet length = 4, too small
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+
+        let err = Event::deserialize(&buf).unwrap_err();
+        let msg = format!("{}", err);
+        assert_eq!(msg, "Invalid packet header: size 4 < header size 8");
+    }
+
+    #[test]
+    fn test_required_bytes_max_packet_length_boundary() {
+        use crate::serialize::Serializable;
+        use crate::types::number::SubunitNumber;
+
+        // MAX_PACKET_LENGTH is accepted
+        let mut buf: Vec<u8> = vec![0xb3];
+        buf.extend_from_slice(&0x2000_u16.to_be_bytes());
+        let num = SubunitNumber::new(crate::constants::MAX_PACKET_LENGTH).unwrap();
+        num.serialize(&mut buf).unwrap();
+        buf.extend(vec![0x00; 100]);
+        let required = Event::required_bytes(&buf).unwrap();
+        assert_eq!(required, crate::constants::MAX_PACKET_LENGTH as usize);
+
+        // MAX_PACKET_LENGTH + 1 is rejected
+        let mut buf2: Vec<u8> = vec![0xb3];
+        buf2.extend_from_slice(&0x2000_u16.to_be_bytes());
+        let num2 = SubunitNumber::new(crate::constants::MAX_PACKET_LENGTH + 1).unwrap();
+        num2.serialize(&mut buf2).unwrap();
+        buf2.extend(vec![0x00; 100]);
+        let err = Event::required_bytes(&buf2).unwrap_err();
+        assert_eq!(format!("{}", err), "Value is too large to encode");
+    }
+
+    #[test]
+    fn test_deserialize_max_packet_length_boundary_deserialize() {
+        use crate::types::number::SubunitNumber;
+
+        // Build a 4MB packet with correct CRC32
+        let packet_length = crate::constants::MAX_PACKET_LENGTH as usize;
+        let mut buf = vec![0u8; packet_length];
+        buf[0] = 0xb3; // signature
+        buf[1..3].copy_from_slice(&0x2000_u16.to_be_bytes()); // version, no features
+        let num = SubunitNumber::new(crate::constants::MAX_PACKET_LENGTH).unwrap();
+        let len_bytes = num.as_bytes();
+        buf[3..3 + len_bytes.len()].copy_from_slice(len_bytes);
+        // Header is 7 bytes (sig + flags + 4-byte length). No features, so
+        // the reader reads 7 bytes then expects CRC32 at bytes[7..11].
+        let header_size = 3 + len_bytes.len(); // 7
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(&buf[..header_size]);
+        let crc = hasher.finalize();
+        buf[header_size..header_size + 4].copy_from_slice(&crc.to_be_bytes());
+
+        let (event, size) = Event::deserialize(&buf).unwrap();
+        assert_eq!(size, packet_length);
+        assert_eq!(event.status, TestStatus::Undefined);
+    }
+
+    #[test]
+    fn test_deserialize_over_max_packet_length() {
+        use crate::serialize::Serializable;
+        use crate::types::number::SubunitNumber;
+
+        // Packet declaring MAX_PACKET_LENGTH + 1 should be rejected
+        let mut buf: Vec<u8> = vec![0xb3];
+        buf.extend_from_slice(&0x2000_u16.to_be_bytes());
+        let num = SubunitNumber::new(crate::constants::MAX_PACKET_LENGTH + 1).unwrap();
+        num.serialize(&mut buf).unwrap();
+        buf.extend(vec![0x00; 100]);
+
+        let err = Event::deserialize(&buf).unwrap_err();
+        assert_eq!(format!("{}", err), "Value is too large to encode");
     }
 }

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -278,4 +278,102 @@ mod tests {
         assert_eq!(number.as_u32(), 0x3FFFFFFF);
         assert_eq!(number.as_bytes(), &[0b11111111, 255, 255, 255]);
     }
+
+    #[test]
+    fn test_wire_size() {
+        use crate::serialize::Serializable;
+        // 1-byte range: 0..=63
+        assert_eq!(
+            SubunitNumber::new(0).unwrap().wire_size().unwrap().as_u32(),
+            1
+        );
+        assert_eq!(
+            SubunitNumber::new(63)
+                .unwrap()
+                .wire_size()
+                .unwrap()
+                .as_u32(),
+            1
+        );
+        // 2-byte range: 64..=16383
+        assert_eq!(
+            SubunitNumber::new(64)
+                .unwrap()
+                .wire_size()
+                .unwrap()
+                .as_u32(),
+            2
+        );
+        assert_eq!(
+            SubunitNumber::new(100)
+                .unwrap()
+                .wire_size()
+                .unwrap()
+                .as_u32(),
+            2
+        );
+        assert_eq!(
+            SubunitNumber::new(16383)
+                .unwrap()
+                .wire_size()
+                .unwrap()
+                .as_u32(),
+            2
+        );
+        // 3-byte range: 16384..=4194303
+        assert_eq!(
+            SubunitNumber::new(16384)
+                .unwrap()
+                .wire_size()
+                .unwrap()
+                .as_u32(),
+            3
+        );
+        assert_eq!(
+            SubunitNumber::new(4194303)
+                .unwrap()
+                .wire_size()
+                .unwrap()
+                .as_u32(),
+            3
+        );
+        // 4-byte range
+        assert_eq!(
+            SubunitNumber::new(4194304)
+                .unwrap()
+                .wire_size()
+                .unwrap()
+                .as_u32(),
+            4
+        );
+    }
+
+    #[test]
+    fn test_debug_format() {
+        let number = SubunitNumber::new(42).unwrap();
+        let debug = format!("{:?}", number);
+        assert_eq!(debug, "SubunitNumber(42 [42])");
+    }
+
+    #[test]
+    fn test_serialize_deserialize_roundtrip() {
+        use crate::deserialize::Deserializable;
+        use crate::serialize::Serializable;
+
+        for value in [
+            0, 1, 63, 64, 100, 16383, 16384, 100000, 4194303, 4194304, 0x3FFFFFFF,
+        ] {
+            let number = SubunitNumber::new(value).unwrap();
+            let mut buf = Vec::new();
+            number.serialize(&mut buf).unwrap();
+            let (deserialized, size) = SubunitNumber::deserialize(&buf).unwrap();
+            assert_eq!(
+                deserialized.as_u32(),
+                value,
+                "Roundtrip failed for {}",
+                value
+            );
+            assert_eq!(size, buf.len(), "Size mismatch for {}", value);
+        }
+    }
 }

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -183,4 +183,77 @@ mod tests {
             assert_eq!(dt, dt_back);
         }
     }
+
+    #[test]
+    fn test_timestamp_serialize_deserialize() {
+        use crate::deserialize::Deserializable;
+        use crate::serialize::Serializable;
+
+        let ts = Timestamp {
+            seconds: 1704067200,
+            nanoseconds: SubunitNumber::new(123456789).unwrap(),
+        };
+        let mut buf = Vec::new();
+        ts.serialize(&mut buf).unwrap();
+
+        let (deserialized, size) = Timestamp::deserialize(&buf).unwrap();
+        assert_eq!(deserialized.seconds, 1704067200);
+        assert_eq!(deserialized.nanoseconds.as_u32(), 123456789);
+        assert_eq!(size, buf.len());
+    }
+
+    #[test]
+    fn test_timestamp_required_bytes_insufficient() {
+        use crate::deserialize::Deserializable;
+
+        // Less than 5 bytes: returns 5
+        let required = Timestamp::required_bytes(&[0x00, 0x00]).unwrap();
+        assert_eq!(required, 5);
+    }
+
+    #[test]
+    fn test_timestamp_required_bytes_exactly_five_one_byte_nanos() {
+        use crate::deserialize::Deserializable;
+
+        // Exactly 5 bytes with 1-byte nanos → required = 4 + 1 = 5
+        let required = Timestamp::required_bytes(&[0x00, 0x00, 0x00, 0x00, 0x00]).unwrap();
+        assert_eq!(required, 5);
+    }
+
+    #[test]
+    fn test_timestamp_required_bytes_exactly_five_two_byte_nanos() {
+        use crate::deserialize::Deserializable;
+
+        // Exactly 5 bytes where byte[4] = 0x40 (TwoBytes marker for nanos)
+        // Original: 5 < 5 → false → check nanos type → TwoBytes → return 4+2=6
+        // Mutated (<=): 5 <= 5 → true → return 5 early (WRONG)
+        let required = Timestamp::required_bytes(&[0x00, 0x00, 0x00, 0x01, 0x40]).unwrap();
+        assert_eq!(required, 6);
+    }
+
+    #[test]
+    fn test_timestamp_deserialize_insufficient() {
+        use crate::deserialize::Deserializable;
+
+        // Only 3 bytes, not enough
+        let result = Timestamp::deserialize(&[0x00, 0x00, 0x00]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_timestamp_required_bytes_exact() {
+        use crate::deserialize::Deserializable;
+        use crate::serialize::Serializable;
+
+        // Serialize a timestamp and check required_bytes matches
+        let ts = Timestamp {
+            seconds: 100,
+            nanoseconds: SubunitNumber::new(50).unwrap(),
+        };
+        let mut buf = Vec::new();
+        ts.serialize(&mut buf).unwrap();
+
+        let required = Timestamp::required_bytes(&buf).unwrap();
+        assert_eq!(required, buf.len());
+    }
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -1844,4 +1844,55 @@ mod tests {
         }
         assert_eq!(BStr::new(&input), BStr::new(&output));
     }
+
+    #[test]
+    fn test_part_debug() {
+        let part = Part::new("text/plain", "example", b"hello");
+        let debug = format!("{:?}", part);
+        assert_eq!(
+            debug,
+            "Part { content_type: \"text/plain\", name: \"example\", bytes: \"hello\" }"
+        );
+    }
+
+    #[test]
+    fn test_protocol_server_debug() {
+        let mut stream: &[u8] = b"test: foo\nsuccess: foo\n";
+        let server = super::TestProtocolServer {
+            reader: &mut stream,
+            state: super::ParseState::Global,
+        };
+        let debug = format!("{:?}", server);
+        assert_eq!(debug, "TestProtocolServer");
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_protocol_server_sync_debug() {
+        let mut stream: &[u8] = b"test: foo\nsuccess: foo\n";
+        let server = super::TestProtocolServerSync {
+            reader: &mut stream,
+            state: super::ParseState::Global,
+        };
+        let debug = format!("{:?}", server);
+        assert_eq!(debug, "TestProtocolServerSync");
+    }
+
+    #[tokio::test]
+    async fn test_write_into_async_tags_multiple() {
+        // Test tags with multiple added and removed to exercise pos += 1
+        // in both the added and removed loops
+        let event = Event::Tags(
+            vec!["foo".to_string()],
+            vec!["bar".to_string(), "baz".to_string()],
+        );
+        let mut output = vec![];
+        <Event as WriteIntoAsync>::write_into(&event, &mut output)
+            .await
+            .unwrap();
+        assert_eq!(
+            std::str::from_utf8(&output).unwrap(),
+            "tags: foo -bar -baz\n"
+        );
+    }
 }


### PR DESCRIPTION
Fix a bug where Event::deserialize would panic (index out of bounds) on crafted packets declaring a packet_length too small to include the CRC32 trailer. The length check now requires packet_length >= bytes_read + 4 to account for the mandatory CRC32 field.

Add tests across all modules guided by cargo-mutants analysis.